### PR TITLE
Add Getting Started section with shared prerequisites

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 1
+---
+
+# Getting Started
+
+Welcome to Ignition Guides - a collection of community guides for working with
+[Ignition SCADA](https://inductiveautomation.com/) using modern development practices.
+
+## What Is in Here
+
+| Section | What You Will Find |
+| --- | --- |
+| [Guides](../guides/version-control/intro.md) | Step-by-step procedures for real workflows (version control, etc.) |
+| [Labs](../labs/git-ignition-lab.md) | Hands-on exercises that walk a workflow end to end |
+| [Reference](../reference/git-style-guide.md) | Quick-reference pages for conventions and standards |
+| [Tools](../tools/overview.md) | Community tools built around Ignition |
+
+## Minimum Setup
+
+Most guides on this site require the same core tools. Set them up once here and every
+guide will reference back to this page rather than repeating the steps.
+
+**Required for all guides:**
+
+- [Workstation Setup](./workstation-setup.md) - VS Code, Git, GitHub CLI, Docker Desktop
+
+**Required for Docker-based guides** (most labs and some advanced guides):
+
+- [Traefik Reverse Proxy](./traefik.md) - Named local URLs instead of port numbers
+  (e.g., `my-gw.localtest.me` instead of `localhost:9088`)
+
+## Where to Start
+
+**New to Git and version control?**
+Start with the [Hands-On Lab](../labs/git-ignition-lab.md). It walks you through a complete
+workflow from cloning to merging a pull request, with explanations along the way.
+
+**Know Git but new to Ignition + Docker workflows?**
+Read the [Version Control Guide](../guides/version-control/intro.md) for context, then
+jump to the lab.
+
+**Looking for a specific procedure?**
+Use the sidebar or search (`Cmd+K` / `Ctrl+K`).

--- a/docs/getting-started/traefik.md
+++ b/docs/getting-started/traefik.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 3
+---
+
+# Traefik Reverse Proxy
+
+**GitHub**: [ia-eknorr/traefik-reverse-proxy](https://github.com/ia-eknorr/traefik-reverse-proxy)
+
+Traefik is a lightweight reverse proxy that runs alongside your Docker stacks and gives
+each service a friendly local URL instead of a port number.
+
+| Without Traefik | With Traefik |
+| --- | --- |
+| `http://localhost:8088` | `http://my-gateway.localtest.me` |
+| `http://localhost:9088` | `http://other-gateway.localtest.me` |
+
+When you are running multiple Ignition gateways locally (common in more advanced setups),
+managing port numbers gets messy fast. Traefik solves this by listening on port 80 and
+routing requests by hostname.
+
+:::note Not required for the basic version control lab
+The [Hands-On Lab](../labs/git-ignition-lab.md) uses `localhost:8088` directly and does
+not require Traefik. This setup becomes useful when running multiple gateways or following
+guides that reference `.localtest.me` URLs.
+:::
+
+## How It Works
+
+`*.localtest.me` is a public wildcard DNS record that always resolves to `127.0.0.1`
+(your own machine). Traefik listens on port 80 and routes requests based on the hostname.
+Docker services opt in by adding a `traefik.hostname` label.
+
+## Setup
+
+Traefik runs as its own Docker Compose stack, separate from your project stacks. Set it up
+once and leave it running.
+
+1. Clone the Traefik repo into a utilities directory (not inside a project):
+
+   ```shell
+   mkdir -p ~/projects/utilities
+   cd ~/projects/utilities
+   git clone https://github.com/ia-eknorr/traefik-reverse-proxy.git traefik
+   cd traefik
+   ```
+
+2. Start Traefik:
+
+   ```shell
+   docker compose up -d
+   ```
+
+   Traefik binds to **port 80**. If something else is using port 80, stop it first.
+
+3. Verify Traefik is running:
+
+   Open [http://proxy.localtest.me](http://proxy.localtest.me) in your browser.
+   You should see the Traefik dashboard.
+
+## Using Traefik with an Ignition Stack
+
+Add these labels to your gateway service in `docker-compose.yml`:
+
+```yaml
+services:
+  gateway:
+    labels:
+      - traefik.enable=true
+      - traefik.hostname=${GATEWAY_NAME}
+```
+
+With `GATEWAY_NAME=my-gw` in your `.env`, the gateway becomes accessible at
+`http://my-gw.localtest.me`.
+
+## Stopping Traefik
+
+```shell
+cd ~/projects/utilities/traefik
+docker compose down
+```
+
+Traefik does not affect other running containers when stopped - they just lose their
+friendly URLs and fall back to direct port access.

--- a/docs/getting-started/workstation-setup.md
+++ b/docs/getting-started/workstation-setup.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Workstation Setup
 
-Before getting started with version control, set up your workstation with the necessary software. The tools below are tried and true in the industry and will serve as a solid starting point.
+These tools are used across all guides on this site. Set them up once here - individual guides will reference this page for prerequisites rather than repeating these steps.
 
 ## Visual Studio Code
 
@@ -35,7 +35,7 @@ If Docker Desktop is already installed, skip this step. Run `docker --version` t
 
 ## Git
 
-IA's preferred version control system.
+The version control system used across all guides.
 
 **Download:**
 
@@ -123,6 +123,12 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
 More information: [GitHub Quickstart](https://docs.github.com/en/get-started/quickstart/set-up-git)
 
+## Windows Users
+
+If you are on Windows, review [Windows Setup Notes](../guides/version-control/wsl-setup.md)
+for Git line-ending configuration and long-path settings.
+
 ---
 
-**Next**: [WSL Setup](./wsl-setup.md) (Windows only) or [Initialize a Repository](./initialize-repository.md)
+**Next**: Pick your guide from the [Getting Started overview](./index.md) or jump straight
+to the [Hands-On Lab](../labs/git-ignition-lab.md).

--- a/docs/guides/version-control/intro.md
+++ b/docs/guides/version-control/intro.md
@@ -86,4 +86,9 @@ git pull origin main
 
 ---
 
-**Next**: [Workstation Setup](./workstation-setup.md)
+:::tip Before continuing
+Make sure [Workstation Setup](../../getting-started/workstation-setup.md) is complete before
+following the procedures in this guide.
+:::
+
+**Next**: [Initialize a Repository](./initialize-repository.md)

--- a/docs/guides/version-control/wsl-setup.md
+++ b/docs/guides/version-control/wsl-setup.md
@@ -11,7 +11,7 @@ and Ignition on Windows.
 
 Docker Desktop for Windows handles Docker natively - WSL is not required to run the
 Ignition Docker stack. If you installed Docker Desktop per the
-[Workstation Setup](./workstation-setup.md) guide, you are ready to go.
+[Workstation Setup](../../getting-started/workstation-setup.md) guide, you are ready to go.
 
 :::tip WSL 2 Backend
 Docker Desktop uses the WSL 2 backend by default on Windows, which improves performance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,13 @@ Unofficial guides for modern Ignition SCADA infrastructure and workflows.
 
 ## What Is in Here
 
+### Getting Started
+
+Tools and setup required across all guides - set up once, referenced everywhere.
+
+- [Workstation Setup](./getting-started/workstation-setup.md) - VS Code, Git, GitHub CLI, Docker Desktop
+- [Traefik Reverse Proxy](./getting-started/traefik.md) - Named local URLs for Docker-based guides
+
 ### Guides
 
 Step-by-step reference guides for working with Ignition in a professional development environment.

--- a/docs/labs/git-ignition-lab.md
+++ b/docs/labs/git-ignition-lab.md
@@ -21,7 +21,7 @@ the directories you care about into the container. Git only sees those directori
 
 Ensure the following are set up:
 
-- [Workstation Setup](../guides/version-control/workstation-setup.md) complete (Git, GitHub CLI, VS Code, Docker Desktop)
+- [Workstation Setup](../getting-started/workstation-setup.md) complete (Git, GitHub CLI, VS Code, Docker Desktop)
 - GitHub account with SSH or HTTPS access configured
 
 ---

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -82,6 +82,7 @@ const config: Config = {
         {
           title: "Guides",
           items: [
+            { label: "Getting Started", to: "/docs/getting-started" },
             { label: "Version Control", to: "/docs/guides/version-control/intro" },
             { label: "Git Lab", to: "/docs/labs/git-ignition-lab" },
             { label: "Style Guide", to: "/docs/reference/git-style-guide" },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -5,6 +5,15 @@ const sidebars: SidebarsConfig = {
     { type: "doc", id: "index", label: "Home" },
     {
       type: "category",
+      label: "Getting Started",
+      link: { type: "doc", id: "getting-started/index" },
+      items: [
+        "getting-started/workstation-setup",
+        "getting-started/traefik",
+      ],
+    },
+    {
+      type: "category",
       label: "Guides",
       items: [
         {
@@ -12,7 +21,6 @@ const sidebars: SidebarsConfig = {
           label: "Version Control",
           link: { type: "doc", id: "guides/version-control/intro" },
           items: [
-            "guides/version-control/workstation-setup",
             "guides/version-control/wsl-setup",
             "guides/version-control/initialize-repository",
             "guides/version-control/branching-strategy",


### PR DESCRIPTION
## Summary

- Adds a top-level **Getting Started** category in the sidebar (before Guides)
- Moves `workstation-setup.md` from `guides/version-control/` to `getting-started/` so it is shared across all guides (DRY)
- Adds `getting-started/index.md` - a primer explaining what the site is, who it is for, and where to start
- Adds `getting-started/traefik.md` - Traefik reverse proxy setup (shared by Docker-based guides that use named URLs)
- Updates footer, landing page, and all internal links accordingly
- Removes workstation-setup from the Version Control sidebar (it lives in Getting Started now)
- Version Control guide intro now links to Getting Started for prerequisites instead of embedding them

## Why

Future guides (Kubernetes, ArgoCD, etc.) will add guide-specific tools (kubectl, helm, etc.) on top of this shared baseline rather than repeating VS Code/Git/Docker setup in every guide.