### PR TITLE
Nav polish: move Windows Setup Notes, remove redundant Next links, add Terminal component

### DIFF
--- a/docs/getting-started/windows-setup.md
+++ b/docs/getting-started/windows-setup.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Windows Setup Notes
@@ -11,7 +11,7 @@ and Ignition on Windows.
 
 Docker Desktop for Windows handles Docker natively - WSL is not required to run the
 Ignition Docker stack. If you installed Docker Desktop per the
-[Workstation Setup](../../getting-started/workstation-setup.md) guide, you are ready to go.
+[Workstation Setup](./workstation-setup.md) guide, you are ready to go.
 
 :::tip WSL 2 Backend
 Docker Desktop uses the WSL 2 backend by default on Windows, which improves performance.
@@ -71,7 +71,3 @@ Then install Git inside WSL and use it from VS Code's integrated terminal (with 
 [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh)).
 Docker commands from WSL will reach Docker Desktop automatically if WSL integration is
 enabled in Docker Desktop settings.
-
----
-
-**Next**: [Initialize a Repository](./initialize-repository.md)

--- a/docs/getting-started/workstation-setup.md
+++ b/docs/getting-started/workstation-setup.md
@@ -63,11 +63,10 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
 1. Verify git installed correctly:
 
-    ```shell
-    git -v
-    ```
-
-    ![Git version output](/img/version-control/git-version.png)
+    <Terminal title="bash — ~" lines={[
+      "$ git -v",
+      "git version 2.47.1",
+    ]} />
 
 2. Configure username and email (shown on commits and pull requests):
 
@@ -125,10 +124,5 @@ More information: [GitHub Quickstart](https://docs.github.com/en/get-started/qui
 
 ## Windows Users
 
-If you are on Windows, review [Windows Setup Notes](../guides/version-control/wsl-setup.md)
+If you are on Windows, review [Windows Setup Notes](./windows-setup.md)
 for Git line-ending configuration and long-path settings.
-
----
-
-**Next**: Pick your guide from the [Getting Started overview](./index.md) or jump straight
-to the [Hands-On Lab](../labs/git-ignition-lab.md).

--- a/docs/guides/version-control/branching-strategy.md
+++ b/docs/guides/version-control/branching-strategy.md
@@ -163,4 +163,3 @@ gitGraph
 Inductive Automation's version control guide covers branching strategies and team environment best practices at [docs.inductiveautomation.com](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide/best-practices-for-team-environments).
 :::
 
-**Next**: [Create a Branch](./create-a-branch.md)

--- a/docs/guides/version-control/create-a-branch.md
+++ b/docs/guides/version-control/create-a-branch.md
@@ -83,7 +83,3 @@ This loosely follows [GitHub Flow](https://docs.github.com/en/get-started/using-
 
     ![git remote -v output showing configured remotes](/img/version-control/remote-sources.png)
     :::
-
----
-
-**Next**: [Create a Pull Request](./create-a-pull-request.md)

--- a/docs/guides/version-control/create-a-pull-request.md
+++ b/docs/guides/version-control/create-a-pull-request.md
@@ -30,7 +30,3 @@ These are different terms for the same thing. GitHub uses "Pull Request"; GitLab
 4. Select **Create Pull Request**.
 
 Once created, the code needs to be reviewed before merging. On solo projects, you can review and merge yourself - but the habit of going through a PR is good practice even when working alone.
-
----
-
-**Next**: [Merge a Pull Request](./merge-a-pull-request.md)

--- a/docs/guides/version-control/initialize-repository.md
+++ b/docs/guides/version-control/initialize-repository.md
@@ -91,7 +91,3 @@ com.inductiveautomation.vision/
 ```
 
 For a host install (non-Docker), track the `data/projects/` directory directly and apply the same ignore patterns.
-
----
-
-**Next**: [Branching Strategy](./branching-strategy.md)

--- a/docs/guides/version-control/intro.md
+++ b/docs/guides/version-control/intro.md
@@ -90,5 +90,3 @@ git pull origin main
 Make sure [Workstation Setup](../../getting-started/workstation-setup.md) is complete before
 following the procedures in this guide.
 :::
-
-**Next**: [Initialize a Repository](./initialize-repository.md)

--- a/docs/guides/version-control/merge-a-pull-request.md
+++ b/docs/guides/version-control/merge-a-pull-request.md
@@ -38,7 +38,3 @@ When the pull request is ready - conflicts resolved, approvals obtained - select
    - **Rebase and merge** - Advanced method; not recommended for most Ignition repos.
 
 ![Resulting merge history after squash and merge](/img/version-control/merge-history.png)
-
----
-
-**Next**: [Style Guide](../../reference/git-style-guide.md)

--- a/docs/reference/git-style-guide.md
+++ b/docs/reference/git-style-guide.md
@@ -163,7 +163,3 @@ For host installs or full data directory mounts, additional patterns may be need
 for the full reference.
 
 See the [Hands-On Lab](../labs/git-ignition-lab.md) for a walkthrough of this structure in practice.
-
----
-
-**Next**: [Hands-On Lab](../labs/git-ignition-lab.md)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -10,6 +10,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "getting-started/workstation-setup",
         "getting-started/traefik",
+        "getting-started/windows-setup",
       ],
     },
     {
@@ -21,7 +22,6 @@ const sidebars: SidebarsConfig = {
           label: "Version Control",
           link: { type: "doc", id: "guides/version-control/intro" },
           items: [
-            "guides/version-control/wsl-setup",
             "guides/version-control/initialize-repository",
             "guides/version-control/branching-strategy",
             "guides/version-control/create-a-branch",

--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+interface TerminalProps {
+  title?: string;
+  // Preferred: one string per line, works inside list items
+  lines?: string[];
+  // Alternative: template literal, works at top level only
+  children?: string;
+}
+
+function renderLine(line: string, i: number) {
+  const isCommand = /^\s*[$%#>]/.test(line);
+  return (
+    <span key={i} className={isCommand ? styles.command : styles.output}>
+      {line}
+      {'\n'}
+    </span>
+  );
+}
+
+export default function Terminal({ title = 'bash', lines, children }: TerminalProps) {
+  const rendered = lines
+    ? lines.map(renderLine)
+    : (children ?? '').replace(/^\n/, '').split('\n').map(renderLine);
+
+  return (
+    <div className={styles.window}>
+      <div className={styles.titleBar}>
+        <div className={styles.dots}>
+          <span className={`${styles.dot} ${styles.red}`} />
+          <span className={`${styles.dot} ${styles.yellow}`} />
+          <span className={`${styles.dot} ${styles.green}`} />
+        </div>
+        <span className={styles.title}>{title}</span>
+      </div>
+      <pre className={styles.content}>{rendered}</pre>
+    </div>
+  );
+}

--- a/src/components/Terminal/styles.module.css
+++ b/src/components/Terminal/styles.module.css
@@ -1,0 +1,66 @@
+.window {
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  margin: 1.25rem 0;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono',
+    'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.titleBar {
+  display: flex;
+  align-items: center;
+  background: #3c3c3c;
+  padding: 9px 14px;
+}
+
+.dots {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex: 0 0 auto;
+  width: 52px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: block;
+  flex-shrink: 0;
+}
+
+.red    { background: #ff5f57; }
+.yellow { background: #ffbd2e; }
+.green  { background: #28ca41; }
+
+.title {
+  flex: 1;
+  text-align: center;
+  color: #9a9a9a;
+  font-size: 0.72rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  user-select: none;
+  padding: 0 52px 0 0; /* offset for dots width to visually center */
+}
+
+.content {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 16px 20px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* Command lines — text that starts with a prompt symbol */
+.command {
+  color: #9ece6a;
+}
+
+/* Dim output lines slightly vs commands */
+.output {
+  color: #c0c0c0;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -102,38 +102,3 @@
     display: none;
   }
 }
-
-/* Terminal window style for shell/bash/powershell code blocks */
-.theme-code-block:has(code[class*="language-shell"]),
-.theme-code-block:has(code[class*="language-bash"]),
-.theme-code-block:has(code[class*="language-powershell"]) {
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-}
-
-.theme-code-block:has(code[class*="language-shell"]) pre,
-.theme-code-block:has(code[class*="language-bash"]) pre,
-.theme-code-block:has(code[class*="language-powershell"]) pre {
-  padding-top: 40px !important;
-  position: relative;
-}
-
-.theme-code-block:has(code[class*="language-shell"]) pre::before,
-.theme-code-block:has(code[class*="language-bash"]) pre::before,
-.theme-code-block:has(code[class*="language-powershell"]) pre::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 38px;
-  background-color: rgba(255, 255, 255, 0.06);
-  background-image:
-    radial-gradient(circle 5px, #ff5f57 100%, transparent 100%),
-    radial-gradient(circle 5px, #ffbd2e 100%, transparent 100%),
-    radial-gradient(circle 5px, #28ca41 100%, transparent 100%);
-  background-position: 14px center, 32px center, 50px center;
-  background-repeat: no-repeat;
-  pointer-events: none;
-}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,16 +24,16 @@
 }
 
 .hero {
-  padding: 4rem 0;
+  padding: clamp(2rem, 5vw, 4rem) 0;
   text-align: center;
 }
 
 .hero__title {
-  font-size: 3rem;
+  font-size: clamp(1.75rem, 5vw, 3rem);
 }
 
 .hero__subtitle {
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
   max-width: 600px;
   margin: 0 auto;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -55,12 +55,27 @@
 
 .feature {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   padding: 1.5rem;
   text-align: center;
   background: #f8fafc;
   border: 1px solid var(--ifm-color-emphasis-300, #cbd5e1);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   border-radius: 8px;
+  text-decoration: none !important;
+  color: inherit !important;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.feature:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.feature__icon {
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.75rem;
 }
 
 .feature h3 {
@@ -68,12 +83,29 @@
 }
 
 .feature p {
+  flex: 1;
   font-size: 0.95rem;
   color: var(--ifm-color-emphasis-700);
 }
 
+.feature__cta {
+  display: block;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}
+
+.feature:hover .feature__cta {
+  text-decoration: underline;
+}
+
 [data-theme="dark"] .feature {
   background: var(--ifm-card-background-color);
+}
+
+[data-theme="dark"] .feature:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 /* Search bar: wider on desktop + keyboard shortcut hint */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,21 +3,58 @@ import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 
-const features = [
+const GitBranchIcon = () => (
+  <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="6" y1="3" x2="6" y2="15" />
+    <circle cx="18" cy="6" r="3" />
+    <circle cx="6" cy="18" r="3" />
+    <circle cx="6" cy="6" r="3" />
+    <path d="M18 9a9 9 0 0 1-9 9" />
+  </svg>
+);
+
+const TerminalIcon = () => (
+  <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="4 17 10 11 4 5" />
+    <line x1="12" y1="19" x2="20" y2="19" />
+  </svg>
+);
+
+const WrenchIcon = () => (
+  <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+  </svg>
+);
+
+type Feature = {
+  title: string;
+  Icon: () => JSX.Element;
+  description: string;
+  to: string;
+  cta: string;
+};
+
+const features: Feature[] = [
   {
     title: "Version Control",
-    description:
-      "Learn Git workflows for Ignition projects: workstation setup, branching strategy, pull requests, and style guidelines.",
+    Icon: GitBranchIcon,
+    description: "Git workflows for Ignition projects: branching strategy, pull requests, and commit conventions.",
+    to: "/docs/guides/version-control/intro",
+    cta: "Read the guide",
   },
   {
-    title: "Hands-On Labs",
-    description:
-      "Follow step-by-step labs that walk through real Ignition workflows. Build muscle memory with practical exercises.",
+    title: "Hands-On Lab",
+    Icon: TerminalIcon,
+    description: "Set up a Docker-based Ignition project with version control end to end, from fork to merged pull request.",
+    to: "/docs/labs/git-ignition-lab",
+    cta: "Start the lab",
   },
   {
     title: "Tools & Ecosystem",
-    description:
-      "Reference pages for community tools built around Ignition: operators, linters, and automation that extend your workflow.",
+    Icon: WrenchIcon,
+    description: "Community tools built around Ignition: operators, linters, and automation that extend your workflow.",
+    to: "/docs/tools/overview",
+    cta: "Browse tools",
   },
 ];
 
@@ -52,12 +89,16 @@ function Features() {
     <section className="features">
       <div className="container">
         <div className="row">
-          {features.map((f, idx) => (
+          {features.map(({ title, Icon, description, to, cta }, idx) => (
             <div key={idx} className={clsx("col col--4")}>
-              <div className="feature">
-                <h3>{f.title}</h3>
-                <p>{f.description}</p>
-              </div>
+              <Link to={to} className="feature">
+                <div className="feature__icon">
+                  <Icon />
+                </div>
+                <h3>{title}</h3>
+                <p>{description}</p>
+                <span className="feature__cta">{cta} →</span>
+              </Link>
             </div>
           ))}
         </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,7 +37,7 @@ function Hero() {
         <div style={{ marginTop: "1.5rem" }}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/guides/version-control/intro"
+            to="/docs/getting-started"
           >
             Get Started
           </Link>

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+import Terminal from '@site/src/components/Terminal';
+
+export default {
+  ...MDXComponents,
+  Terminal,
+};


### PR DESCRIPTION
## Summary

- Moves **Windows Setup Notes** out of the Version Control guide and into Getting Started (it's platform setup, not a guide step, and not relevant to all users)
- Removes all manual `**Next:**` footer links - Docusaurus renders prev/next navigation automatically at the bottom of every page, so these were duplicates
- Updates **Get Started** button on homepage to point to `/docs/getting-started` instead of dropping users directly into the version control guide
- Adds the **Terminal component** (`src/components/Terminal`) globally via `MDXComponents.tsx` - renders a macOS-style terminal window for command output, already used in `workstation-setup.md`
- Removes the redundant global CSS approach for terminal-style code blocks (the component's CSS module handles this more precisely)

## Reviewer Notes

- `sidebars.ts`: `wsl-setup` removed from Version Control items; `windows-setup` added to Getting Started items
- Docusaurus auto-nav order after the change: Getting Started (index → workstation-setup → traefik → windows-setup) → Guides > Version Control (intro → initialize-repository → branching-strategy → create-a-branch → create-a-pull-request → merge-a-pull-request) → Labs → Reference → Tools
- The `<Terminal>` component is usable in any MDX file without importing - registered globally in `src/theme/MDXComponents.tsx`