### PR TITLE
add Terminal component and replace terminal screenshots

### DIFF
--- a/.lint/.markdownlint.json
+++ b/.lint/.markdownlint.json
@@ -4,6 +4,7 @@
   "whitespace": false,
   "MD013": false,
   "MD024": false,
+  "MD033": { "allowed_elements": ["Terminal"] },
   "MD046":
   {
     "style": "fenced"

--- a/docs/getting-started/workstation-setup.md
+++ b/docs/getting-started/workstation-setup.md
@@ -77,10 +77,12 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
 3. Verify:
 
-    ```shell
-    git config --global user.name
-    git config --global user.email
-    ```
+    <Terminal title="bash — ~" lines={[
+      "$ git config --global user.name",
+      "your-username",
+      "$ git config --global user.email",
+      "your@email.com",
+    ]} />
 
 ## GitHub CLI
 
@@ -104,21 +106,26 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
 1. Verify installation:
 
-    ```shell
-    gh status
-    ```
-
-    ![GitHub CLI configuration](/img/version-control/gh-configuration.png)
+    <Terminal title="bash — ~" lines={[
+      "$ gh status",
+      "You are not logged into any GitHub hosts. Run `gh auth login` to authenticate.",
+    ]} />
 
 2. Authenticate:
 
-    ```shell
-    gh auth login
-    ```
-
-    Follow the prompts to log in to GitHub.
-
-    ![GitHub auth login](/img/version-control/gh-auth-login.png)
+    <Terminal title="bash — ~" lines={[
+      "$ gh auth login",
+      "? What account do you want to log into? GitHub.com",
+      "? What is your preferred protocol for Git operations? HTTPS",
+      "? Authenticate Git with your GitHub credentials? Yes",
+      "? How would you like to authenticate GitHub CLI? Login with a web browser",
+      "",
+      "! First copy your one-time code: C464-3A9D",
+      "Press Enter to open github.com in your browser...",
+      "✓ Authentication complete.",
+      "✓ Configured git protocol",
+      "✓ Logged in as your-username",
+    ]} />
 
 More information: [GitHub Quickstart](https://docs.github.com/en/get-started/quickstart/set-up-git)
 

--- a/docs/guides/version-control/create-a-branch.md
+++ b/docs/guides/version-control/create-a-branch.md
@@ -14,16 +14,17 @@ This loosely follows [GitHub Flow](https://docs.github.com/en/get-started/using-
 
 1. Check available branches and your current branch:
 
-    ```shell
-    git branch
-    ```
+    <Terminal title="bash — ~" lines={[
+      "$ git branch",
+      "* main",
+    ]} />
 
 2. Create and switch to a new branch:
 
-    ```shell
-    # Create and checkout in one command
-    git checkout -b branch-name
-    ```
+    <Terminal title="bash — ~" lines={[
+      "$ git checkout -b feature/my-feature",
+      "Switched to a new branch 'feature/my-feature'",
+    ]} />
 
     :::tip
     Per the [Style Guide](../../reference/git-style-guide.md), avoid developing directly on `main`. Create a feature branch with a descriptive name.
@@ -63,11 +64,11 @@ This loosely follows [GitHub Flow](https://docs.github.com/en/get-started/using-
 
 7. Verify a clean working tree:
 
-    ```shell
-    git status
-    ```
-
-    ![Clean working tree output](/img/version-control/clean-working-tree.png)
+    <Terminal title="bash — ~" lines={[
+      "$ git status",
+      "On branch feature/my-feature",
+      "nothing to commit, working tree clean",
+    ]} />
 
 8. Push to the remote repository:
 
@@ -81,5 +82,9 @@ This loosely follows [GitHub Flow](https://docs.github.com/en/get-started/using-
     :::tip Forgot the remote name?
     Run `git remote -v` to list all configured remotes.
 
-    ![git remote -v output showing configured remotes](/img/version-control/remote-sources.png)
+    <Terminal title="bash — ~" lines={[
+      "$ git remote -v",
+      "origin    https://github.com/your-org/your-repo.git (fetch)",
+      "origin    https://github.com/your-org/your-repo.git (push)",
+    ]} />
     :::

--- a/docs/labs/git-ignition-lab.md
+++ b/docs/labs/git-ignition-lab.md
@@ -132,14 +132,20 @@ If this is the first startup, complete the commissioning wizard:
 
 Back in VS Code, open the integrated terminal and run:
 
-```shell
-git status
-```
+<Terminal title="bash — ~/my-ignition-project">
+{`$ git status
+On branch main
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   services/ignition/projects/my_project/com.inductiveautomation.perspective/views/example_view/resource.json
+        modified:   services/ignition/projects/my_project/com.inductiveautomation.perspective/views/example_view/view.json
+
+no changes added to commit (use "git add" and/or "git commit -a")`}
+</Terminal>
 
 The new project files appear under `services/ignition/projects/my_project/`. This is the
 bind mount at work - no export or copy was needed.
-
-![git status showing new project files](/img/lab/git-status.png)
 
 Run `git diff` on one of the files to see what changed:
 
@@ -186,9 +192,10 @@ for the full pattern reference including host install patterns.
 
 Create a feature branch for your changes (do not commit directly to `main`):
 
-```shell
-git checkout -b feature/add-initial-view
-```
+<Terminal title="bash — ~/my-ignition-project">
+{`$ git checkout -b feature/add-initial-view
+Switched to a new branch 'feature/add-initial-view'`}
+</Terminal>
 
 Stage the project directory and commit:
 
@@ -199,11 +206,23 @@ git commit -m "feat: add initial perspective view"
 
 Push to GitHub:
 
-```shell
-git push -u origin HEAD
-```
-
-![git push output with PR link](/img/lab/new-branch-push.png)
+<Terminal title="bash — ~/my-ignition-project">
+{`$ git push -u origin HEAD
+Enumerating objects: 8, done.
+Counting objects: 100% (8/8), done.
+Delta compression using up to 10 threads
+Compressing objects: 100% (5/5), done.
+Writing objects: 100% (6/6), 1.24 KiB | 1.24 MiB/s, done.
+Total 6 (delta 2), reused 0 (delta 0), pack-reused 0
+remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+remote:
+remote: Create a pull request for 'feature/add-initial-view' on GitHub by visiting:
+remote:     https://github.com/your-org/your-repo/pull/new/feature/add-initial-view
+remote:
+To https://github.com/your-org/your-repo.git
+ * [new branch]      HEAD -> feature/add-initial-view
+Branch 'feature/add-initial-view' set up to track remote branch 'feature/add-initial-view' from 'origin'.`}
+</Terminal>
 
 :::tip Commit message style
 Using prefixes like `feat:`, `fix:`, and `chore:` (Conventional Commits) makes it easy to
@@ -236,12 +255,23 @@ After pushing, Git prints a URL to create a pull request. Open it, or navigate t
 
 After merging, bring `main` up to date:
 
-```shell
-git checkout main
-git pull origin main
-```
-
-![git pull output](/img/lab/pull-remote-changes.png)
+<Terminal title="bash — ~/my-ignition-project">
+{`$ git checkout main
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.
+$ git pull origin main
+remote: Enumerating objects: 1, done.
+remote: Counting objects: 100% (1/1), done.
+remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
+Unpacking objects: 100% (1/1), 276 bytes | 276.00 KiB/s, done.
+From https://github.com/your-org/your-repo
+ * branch            main       -> FETCH_HEAD
+   9f805c2..31f1139  main       -> origin/main
+Updating 9f805c2..31f1139
+Fast-forward
+ services/ignition/projects/my_project/.../view.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)`}
+</Terminal>
 
 Your local `main` now matches the remote. Start the next feature with a new branch off `main`.
 

--- a/docs/labs/git-ignition-lab.md
+++ b/docs/labs/git-ignition-lab.md
@@ -136,8 +136,8 @@ Back in VS Code, open the integrated terminal and run:
 {`$ git status
 On branch main
 Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git restore <file>..." to discard changes in working directory)
+  (use "git add [file]..." to update what will be committed)
+  (use "git restore [file]..." to discard changes in working directory)
         modified:   services/ignition/projects/my_project/com.inductiveautomation.perspective/views/example_view/resource.json
         modified:   services/ignition/projects/my_project/com.inductiveautomation.perspective/views/example_view/view.json
 

--- a/src/components/Terminal/styles.module.css
+++ b/src/components/Terminal/styles.module.css
@@ -43,7 +43,7 @@
   font-size: 0.72rem;
   font-family: system-ui, -apple-system, sans-serif;
   user-select: none;
-  padding: 0 52px 0 0; /* offset for dots width to visually center */
+  padding: 0 52px 0 0;
 }
 
 .content {
@@ -55,12 +55,10 @@
   white-space: pre;
 }
 
-/* Command lines — text that starts with a prompt symbol */
 .command {
   color: #9ece6a;
 }
 
-/* Dim output lines slightly vs commands */
 .output {
   color: #c0c0c0;
 }


### PR DESCRIPTION
### Background

Terminal screenshots go stale and are platform-specific. A rendered component keeps docs accurate without retaking screenshots.

### Changes

- New `Terminal` React component (`src/components/Terminal/`) with macOS-style window chrome: title bar, colored dots, dark content area
- Registered globally via `src/theme/MDXComponents.tsx` - no import needed in doc files
- Lines starting with `$`, `%`, `#`, or `>` render in green as commands; output lines render dimmer
- Two usage patterns: `lines={[...]}` prop for inside list items (avoids MDX lazy-line parse errors), template literal children for top-level blocks
- Replaced 8 terminal screenshots across `workstation-setup.md`, `create-a-branch.md`, and `git-ignition-lab.md`
- Upgraded 6 plain shell code blocks to Terminal where showing expected output adds clarity

### Reviewer Notes

Deleted screenshot files are not removed from `static/img/` in this PR - can be cleaned up separately once confident nothing else references them.