### PR TITLE
fix: remove incorrect Ignition 8.2 version reference

### DIFF
--- a/docs/guides/version-control/initialize-repository.md
+++ b/docs/guides/version-control/initialize-repository.md
@@ -50,8 +50,8 @@ The local repository is now linked with the remote and ready to accept changes.
 
 ## Ignition 8.3 Directory Structure
 
-:::note Coming from Ignition 8.1 or 8.2?
-In 8.1/8.2, gateway configuration lived in a SQLite database and could only be backed up
+:::note Coming from Ignition 8.1?
+In 8.1, gateway configuration lived in a SQLite database and could only be backed up
 as a `.gwbk` file - not tracked in Git. In 8.3, all gateway configuration moved to the
 filesystem under `data/config/`, making it directly version-controllable alongside your
 projects. See the [Ignition 8.3 Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide)


### PR DESCRIPTION
## Background

Ignition skipped version 8.2 entirely - the version history goes 8.1 → 8.3. A note in `initialize-repository.md` incorrectly referenced "8.1 or 8.2" and "In 8.1/8.2".

## Changes

- Updated the admonition header from "Coming from Ignition 8.1 or 8.2?" to "Coming from Ignition 8.1?"
- Removed "8.2" from the body copy

## Testing Notes

- Verify the note in the Initialize Repository guide reads correctly