### PR TITLE
chore: fix badge underline artifact, remove redundant nav hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml">
-    <img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" />
-  </a>
-  <a href="https://ia-eknorr.github.io/ignition-guides/">
-    <img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" />
-  </a>
-  <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
-  </a>
+  <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml"><img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
+  <a href="https://ia-eknorr.github.io/ignition-guides/"><img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
 </p>
 
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -39,6 +39,3 @@ workflow from cloning to merging a pull request, with explanations along the way
 **Know Git but new to Ignition + Docker workflows?**
 Read the [Version Control Guide](../guides/version-control/intro.md) for context, then
 jump to the lab.
-
-**Looking for a specific procedure?**
-Use the sidebar or search (`Cmd+K` / `Ctrl+K`).


### PR DESCRIPTION
## Changes

- **README badges**: collapsed each `<a><img></a>` onto one line to eliminate the whitespace text node that GitHub renders as a blue underline between badges
- **Getting Started index**: removed "Looking for a specific procedure? Use the sidebar or search" - users know how to navigate a docs site