### PR TITLE
Add Gateway Resource Collections reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml">
-    <img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" />
-  </a>
-  <a href="https://ia-eknorr.github.io/ignition-guides/">
-    <img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" />
-  </a>
-  <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
-  </a>
+  <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml"><img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
+  <a href="https://ia-eknorr.github.io/ignition-guides/"><img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
 </p>
 
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -39,6 +39,3 @@ workflow from cloning to merging a pull request, with explanations along the way
 **Know Git but new to Ignition + Docker workflows?**
 Read the [Version Control Guide](../guides/version-control/intro.md) for context, then
 jump to the lab.
-
-**Looking for a specific procedure?**
-Use the sidebar or search (`Cmd+K` / `Ctrl+K`).

--- a/docs/guides/version-control/initialize-repository.md
+++ b/docs/guides/version-control/initialize-repository.md
@@ -65,8 +65,11 @@ When using Docker with the `ia-eknorr/project-template`:
 | Directory | What it Contains |
 | --- | --- |
 | `services/ignition/projects/` | Ignition projects (tracked) |
-| `services/ignition/config/` | Gateway configuration (tracked) |
+| `services/ignition/config/resources/core/` | Shared gateway config (tracked) |
+| `services/ignition/config/resources/dev/` | Dev environment config (tracked) |
 | `data/` (Docker volume) | Runtime data - not tracked |
+
+See [Gateway Resource Collections](../../reference/resource-collections.md) for a full explanation of the `core/` and `dev/` directories and how to add more environments.
 
 ### Recommended .gitignore
 

--- a/docs/labs/git-ignition-lab.md
+++ b/docs/labs/git-ignition-lab.md
@@ -85,8 +85,8 @@ The template starts the gateway in `dev` deployment mode. Deployment modes allow
 config repository to serve multiple environments (dev, QA, prod) by layering
 environment-specific overrides at runtime - but this only applies to gateway configuration,
 not Perspective projects. For this lab the `dev` mode is pre-set and requires no changes.
-See the [Ignition 8.3 Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide)
-for more on deployment modes.
+See [Gateway Resource Collections](../reference/resource-collections.md) for a full
+explanation of the collection hierarchy and when to use deployment modes.
 :::
 
 ---

--- a/docs/reference/resource-collections.md
+++ b/docs/reference/resource-collections.md
@@ -149,6 +149,7 @@ The `project-template` mounts `core/` and `dev/` into the container. Both direct
 Every collection directory requires a `config-mode.json` file:
 
 **Core:**
+
 ```json
 {
   "title": "Core",
@@ -160,6 +161,7 @@ Every collection directory requires a `config-mode.json` file:
 ```
 
 **Deployment mode:**
+
 ```json
 {
   "title": "Dev",

--- a/docs/reference/resource-collections.md
+++ b/docs/reference/resource-collections.md
@@ -1,0 +1,267 @@
+---
+sidebar_position: 2
+---
+
+# Gateway Resource Collections
+
+Ignition 8.3 organizes gateway configuration through a hierarchy of resource collections. Understanding this hierarchy is essential for knowing what to track in Git, what to ignore, and how to handle multiple environments.
+
+For the official reference, see [Gateway Deployment Modes](https://docs.inductiveautomation.com/docs/8.3/platform/gateway/web-interface/platform/gateway-deployment-modes).
+
+## Collection Hierarchy
+
+```text
+system → external → core → deployment-mode → local
+```
+
+Resources defined in lower collections (right side) override resources with the same name from higher collections (left side).
+
+### System
+
+Built-in, immutable resources provided by Ignition (default JDBC drivers, system config). Cannot be modified directly, but can be overridden in lower collections.
+
+### External
+
+Read-only resources managed outside the Gateway UI - typically version-controlled files. Use external for:
+
+- Settings that operators should not be able to change through the Gateway web interface
+- Shared configurations used by multiple gateways
+- Centrally managed base configurations
+
+Changes must be made in source files and reloaded rather than through the UI.
+
+### Core
+
+The default working collection. Core resources:
+
+- Are editable through the Gateway web interface
+- Inherit from external (and system)
+- Provide the base configuration for all deployment modes
+- Must contain all singleton resources, even if overridden in deployment modes
+
+### Deployment Modes
+
+User-defined collections for environment-specific configuration. Each deployment mode:
+
+- Inherits from core by default
+- Contains environment-specific overrides and additions
+- Is activated by setting the `DEPLOYMENT_MODE` environment variable
+
+The `project-template` uses `dev` as its deployment mode, set via `DEPLOYMENT_MODE=dev` in `.env.example`.
+
+### Local
+
+Host-specific data that should not be shared (certificates, local secrets). Not inherited by deployment modes and not version controlled.
+
+## Resource Types
+
+### Named Resources
+
+Individual items that appear in lists - you can have zero, one, or many of them:
+
+| Resource Type | Example Names |
+| --- | --- |
+| Database connections | `production`, `dev-db`, `historian` |
+| Tag providers | `default`, `edge-devices` |
+| Alarm journals | `main-journal` |
+| User sources | `internal`, `ldap-prod` |
+| Gateway network connections | `backend-gw` |
+| Identity providers | `default`, `sso-prod` |
+
+Named resources can exist only in specific collections, or override a parent collection's resource of the same name.
+
+### Singleton Resources
+
+Single configuration objects - exactly one per gateway:
+
+| Singleton Resource | Description |
+| --- | --- |
+| `gateway-network-settings` | Global gateway network configuration |
+| `system-properties` | Gateway system properties |
+| `security-properties` | Security settings |
+| `security-levels` | Security level definitions |
+| `general-alarm-settings` | Global alarm configuration |
+
+:::warning
+All singleton resources **must exist in core** (or external), even if you override them in a deployment mode. The gateway needs a base configuration to start with. A singleton that exists only in a deployment mode will cause the gateway to fail to start.
+:::
+
+## What Goes Where
+
+### Core
+
+Place resources in `core` when they are identical across all environments:
+
+| Resource Type | Examples |
+| --- | --- |
+| Perspective session properties | Theme, general UI settings |
+| OPC-UA settings | Connections to local simulators |
+| Module configurations | Settings without external endpoints |
+| Tag definitions | UDT definitions, tag types |
+| Translations | Localization files |
+| Singleton base configs | `gateway-network-settings`, `system-properties` |
+
+### Deployment Modes
+
+Place resources in a deployment mode when they contain environment-specific values:
+
+| Resource Type | Why It Varies |
+| --- | --- |
+| Database connections | Different hosts or credentials per environment |
+| Remote tag providers | Point to different backend gateways |
+| Alarm journals | Write to different databases |
+| Gateway network connections | Different backend addresses per environment |
+| Identity providers | Different IdP configs (dev vs prod SSO) |
+| User sources | Different user databases or LDAP servers |
+
+:::tip
+If a resource contains a hostname, IP address, connection string, or credentials, it belongs in a deployment mode rather than core.
+:::
+
+## Directory Structure
+
+```text
+services/ignition/config/resources/
+├── core/                           # Shared across all modes
+│   ├── config-mode.json
+│   ├── ignition/
+│   │   ├── gateway-network-settings/   # Singleton - must be here
+│   │   ├── system-properties/
+│   │   └── tag-provider/default/
+│   └── com.inductiveautomation.perspective/
+│       └── session-props/
+├── dev/                            # Local development overrides
+│   ├── config-mode.json
+│   └── ignition/
+│       ├── database-connection/
+│       └── system-properties/      # Overrides core
+└── prod/                           # Production overrides
+    ├── config-mode.json
+    └── ignition/
+        ├── database-connection/    # Different host/credentials
+        └── system-properties/
+```
+
+The `project-template` mounts `core/` and `dev/` into the container. Both directories are tracked in Git.
+
+## config-mode.json
+
+Every collection directory requires a `config-mode.json` file:
+
+**Core:**
+```json
+{
+  "title": "Core",
+  "description": "Core collection of gateway configuration resources",
+  "enabled": true,
+  "inheritable": true,
+  "parent": "external"
+}
+```
+
+**Deployment mode:**
+```json
+{
+  "title": "Dev",
+  "description": "Local development environment",
+  "enabled": true,
+  "inheritable": true,
+  "parent": "core"
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `title` | Display name shown in the Gateway web interface |
+| `description` | Optional description |
+| `enabled` | Whether this collection is active |
+| `inheritable` | Whether other collections can inherit from this one |
+| `parent` | Parent collection (`system`, `external`, `core`, or another mode name) |
+
+## Setting Up a Deployment Mode
+
+1. Create the directory:
+
+    ```shell
+    mkdir -p services/ignition/config/resources/prod/ignition
+    ```
+
+2. Create `config-mode.json`:
+
+    ```json
+    {
+      "title": "Production",
+      "description": "",
+      "enabled": true,
+      "inheritable": true,
+      "parent": "core"
+    }
+    ```
+
+3. Add environment-specific resources.
+
+4. Activate by setting `DEPLOYMENT_MODE=prod` in `.env` and restarting:
+
+    ```shell
+    docker compose down && docker compose up -d
+    ```
+
+## Common Patterns
+
+### Single Environment (project-template default)
+
+The simplest setup - `core` for shared config, `dev` for anything local:
+
+```text
+config/resources/
+├── core/
+└── dev/
+```
+
+### Multi-Environment
+
+For projects that deploy to dev, test, and production:
+
+```text
+config/resources/
+├── core/       # Shared application config
+├── dev/        # Local development (localhost DBs, relaxed security)
+├── test/       # QA environment
+└── prod/       # Production (production DBs, full security)
+```
+
+### Multi-Region Production
+
+For multi-region deployments:
+
+```text
+config/resources/
+├── core/
+├── dev/
+├── prod-us-east/
+├── prod-eu-central/
+└── prod-ap-southeast/
+```
+
+Each region has its own database connections and gateway network connections pointing to regional infrastructure.
+
+## FAQ
+
+**What's the difference between external and core?**
+External is read-only via the Gateway UI - changes must come from files. Core is editable through the web interface. Use external when you want to prevent operators from accidentally changing a setting.
+
+**Can I use deployment modes without an external collection?**
+Yes. External is optional. Most simple projects just use `core` and one or more deployment modes.
+
+**Can a named resource exist only in a deployment mode?**
+Yes. Database connections, tag providers, and other named resources can exist in a single mode with no corresponding entry in core.
+
+**Can a singleton resource exist only in a deployment mode?**
+No. Singletons like `gateway-network-settings` and `system-properties` must exist in `core` or `external` first. Deployment modes can override them but not create them from scratch.
+
+**How do I reload resources without restarting the gateway?**
+Use the "Scan File System" option in the Gateway web interface under Config, or via the API:
+
+```shell
+curl -X POST http://localhost:8088/data/api/v1/scan/config
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -39,7 +39,7 @@ const sidebars: SidebarsConfig = {
     {
       type: "category",
       label: "Reference",
-      items: ["reference/git-style-guide"],
+      items: ["reference/git-style-guide", "reference/resource-collections"],
     },
     {
       type: "category",


### PR DESCRIPTION
## Summary

- Ports the resource collections guide from docs-common as a new `Reference/Gateway Resource Collections` page
- Strips IA-internal content (SE team framing, multi-repository patterns specific to Public Demo)
- Keeps all technically useful content: hierarchy overview, named vs singleton resources, what belongs in core vs deployment modes, directory structure, config-mode.json reference, common patterns, FAQ
- Adds sidebar entry under Reference
- Links from `initialize-repository.md` (directory table now shows `core/` and `dev/` specifically)
- Links from the lab's deployment mode note (replaces the generic IA docs link)