### PR TITLE
fix: use your@email.com placeholder in git config example

### DIFF
--- a/docs/getting-started/workstation-setup.md
+++ b/docs/getting-started/workstation-setup.md
@@ -72,7 +72,7 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
     ```shell
     git config --global user.name "your username"
-    git config --global user.email "your email"
+    git config --global user.email "your@email.com"
     ```
 
 3. Verify:


### PR DESCRIPTION
Replaces the vague `"your email"` placeholder with `"your@email.com"` to match the verify step output directly below it.