### PR TITLE
Add missing cross-links

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -13,7 +13,7 @@ Welcome to Ignition Guides - a collection of community guides for working with
 | --- | --- |
 | [Guides](../guides/version-control/intro.md) | Step-by-step procedures for real workflows (version control, etc.) |
 | [Labs](../labs/git-ignition-lab.md) | Hands-on exercises that walk a workflow end to end |
-| [Reference](../reference/git-style-guide.md) | Quick-reference pages for conventions and standards |
+| [Reference](../reference/git-style-guide.md) | Quick-reference pages for conventions, standards, and Ignition concepts |
 | [Tools](../tools/overview.md) | Community tools built around Ignition |
 
 ## Minimum Setup

--- a/docs/guides/version-control/initialize-repository.md
+++ b/docs/guides/version-control/initialize-repository.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Initialize a Local Repository
 
 :::tip Using Docker?
-If you are using the `ia-eknorr/project-template` Docker setup, skip this page. The template already includes a pre-initialized repository structure. Fork the template on GitHub and clone it instead of following the steps below.
+If you are using the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template) Docker setup, skip this page. The template already includes a pre-initialized repository structure. Fork the template on GitHub and clone it instead of following the steps below.
 :::
 
 ## Procedure
@@ -60,7 +60,7 @@ for the full picture.
 
 In Ignition 8.3, project and configuration files are stored on the filesystem (not in a SQLite database), making them directly trackable with Git.
 
-When using Docker with the `ia-eknorr/project-template`:
+When using Docker with the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template):
 
 | Directory | What it Contains |
 | --- | --- |

--- a/docs/guides/version-control/intro.md
+++ b/docs/guides/version-control/intro.md
@@ -38,7 +38,7 @@ Version control allows a team to:
 
 | **Keyword** | **Description** |
 | --- | --- |
-| `Branch` | Pointer to a commit |
+| `Branch` | Pointer to a commit - see [Branching Strategies](./branching-strategy.md) |
 | `Cache` | Local memory intended to temporarily store uncommitted changes |
 | `CLI` | Command Line Interface |
 | `Commit` | Stores the current contents of the index in a new commit along with a log message |
@@ -48,7 +48,7 @@ Version control allows a team to:
 | `Local Repository` | Where you keep your copy of a Git repository on your workstation |
 | `Main` | Default name of the first branch |
 | `Merge` | Joining two or more commit histories |
-| `Pull Request` | GitHub-specific term to let others know about changes you've pushed to a branch |
+| `Pull Request` | GitHub-specific term to let others know about changes you've pushed to a branch - see [Create a Pull Request](./create-a-pull-request.md) |
 | `Remote Repository` | A repository where you push changes for collaboration or backup |
 | `Stash` | Another cache, acting as a stack, where changes can be stored without committing |
 | `Working tree` | Current branch in your workspace |

--- a/docs/labs/git-ignition-lab.md
+++ b/docs/labs/git-ignition-lab.md
@@ -266,7 +266,7 @@ After pushing, Git prints a URL to create a pull request. Open it, or navigate t
 
    ![Pull Request Page](/img/lab/pull-request-page.png)
 
-4. Select **Squash and merge** to keep a clean commit history on `main`
+4. Select **Squash and merge** to keep a clean commit history on `main` - see [Merge a Pull Request](../guides/version-control/merge-a-pull-request.md) for a comparison of all three merge strategies
 
 ---
 
@@ -329,3 +329,5 @@ Your local `main` now matches the remote. Start the next feature with a new bran
 - [Additive Approach](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach) - The bind-mount strategy used in this lab
 - [Version Control Guide](../guides/version-control/intro.md) - Git basics and branching strategies
 - [Git Style Guide](../reference/git-style-guide.md) - Naming conventions and commit standards
+- [Gateway Resource Collections](../reference/resource-collections.md) - Deep dive on core, deployment modes, and what to put where
+- [Traefik Reverse Proxy](../getting-started/traefik.md) - Named local URLs when running multiple gateways


### PR DESCRIPTION
- Link `ia-eknorr/project-template` mentions in initialize-repository.md to the GitHub repo (2 spots)