### PR TITLE
chore: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -35,7 +35,7 @@ jobs:
       - name: Check links
         run: npx --yes markdown-link-check docs/**/*.md --config .mlc-config.json
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         if: github.ref == 'refs/heads/main'
         with:
           path: build
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,7 +9,7 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v17


### PR DESCRIPTION
## Background

GitHub is deprecating Node.js 20 on Actions runners. Actions will be forced to Node.js 24 by default on June 2nd, 2026, and Node.js 20 will be removed entirely on September 16th, 2026.

## Changes

- `actions/checkout`: v4 → v6
- `actions/setup-node`: v4 → v6
- `actions/upload-pages-artifact`: v3 → v5
- `actions/deploy-pages`: v4 → v5

## Testing Notes

CI should pass with no Node.js 20 deprecation warnings.