### PR TITLE
fix admonitions broken by future.v4 flag

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,6 +20,9 @@ const config: Config = {
     hooks: {
       onBrokenMarkdownLinks: "warn",
     },
+    mdx1Compat: {
+      admonitions: true,
+    },
   },
 
   themes: [


### PR DESCRIPTION
### Background

`future: { v4: true }` enables `mdx1CompatDisabledByDefault`, which turns off the admonitions remark plugin. All `:::tip`, `:::note`, and `:::warning` blocks were rendering as raw text instead of styled callouts.

### Changes

Added `markdown.mdx1Compat.admonitions: true` to `docusaurus.config.ts` to explicitly re-enable admonition parsing.

### Reviewer Notes

This is the recommended opt-in path from Docusaurus — `v4: true` is a forward-compatibility flag that disables MDX1 features as a bundle, but individual features can be re-enabled explicitly.