### PR TITLE
parameterize ignition version with remark substitution + renovate

### DIFF
--- a/.lint/.markdownlint.json
+++ b/.lint/.markdownlint.json
@@ -4,7 +4,8 @@
   "whitespace": false,
   "MD013": false,
   "MD024": false,
-  "MD033": { "allowed_elements": ["Terminal"] },
+  "MD033": { "allowed_elements": ["Terminal", "file"] },
+  "MD050": false,
   "MD046":
   {
     "style": "fenced"

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -11,8 +11,8 @@ Welcome to Ignition Guides - a collection of community guides for working with
 
 | Section | What You Will Find |
 | --- | --- |
-| [Guides](../guides/version-control/intro.md) | Step-by-step procedures for real workflows |
-| [Labs](../labs/version-control-lab.md) | Hands-on exercises that walk a workflow end to end |
+| [Guides](../guides/docker/intro.md) | Step-by-step procedures for real workflows |
+| [Labs](../labs/docker-ignition-lab.md) | Hands-on exercises that walk a workflow end to end |
 | [Reference](../reference/git-style-guide.md) | Quick-reference pages for conventions, standards, and Ignition concepts |
 | [Tools](../tools/overview.md) | Community tools built around Ignition |
 
@@ -39,14 +39,7 @@ flowchart TD
     TR["Traefik\n(required for labs)"]
 
     WS --> TR
-    WS --> FOUNDATIONS
-
-    subgraph FOUNDATIONS ["Foundations"]
-        direction TB
-        FG["Version Control"]
-        FL["Lab"]
-        FG --> FL
-    end
+    WS --> CONTAINERIZATION
 
     subgraph CONTAINERIZATION ["Containerization"]
         direction TB
@@ -55,11 +48,18 @@ flowchart TD
         CG --> CL
     end
 
-    TR --> FL
-    FL --> CONTAINERIZATION
+    subgraph VERSION_CONTROL ["Version Control"]
+        direction TB
+        VG["Git Workflow"]
+        VL["Lab"]
+        VG --> VL
+    end
+
     TR --> CL
+    CL --> VERSION_CONTROL
+    TR --> VL
 ```
 
-**Foundations** covers Git, GitHub, and version control workflows for Ignition projects. Start here if you are new to tracking Ignition configuration in source control.
+**Containerization** covers Docker Compose, the project-template architecture, licensing, and day-to-day gateway operations. Start here to run an Ignition gateway locally with the project-template.
 
-**Containerization** covers Docker Compose, the project-template architecture, licensing, and day-to-day gateway operations. Start here if you are comfortable with Git but new to running Ignition in containers.
+**Version Control** covers Git, GitHub, and source control workflows for the Ignition project files produced by your gateway. Continue here once you have a running gateway and want to track its configuration in Git.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -11,31 +11,55 @@ Welcome to Ignition Guides - a collection of community guides for working with
 
 | Section | What You Will Find |
 | --- | --- |
-| [Guides](../guides/version-control/intro.md) | Step-by-step procedures for real workflows (version control, etc.) |
-| [Labs](../labs/git-ignition-lab.md) | Hands-on exercises that walk a workflow end to end |
+| [Guides](../guides/version-control/intro.md) | Step-by-step procedures for real workflows |
+| [Labs](../labs/version-control-lab.md) | Hands-on exercises that walk a workflow end to end |
 | [Reference](../reference/git-style-guide.md) | Quick-reference pages for conventions, standards, and Ignition concepts |
 | [Tools](../tools/overview.md) | Community tools built around Ignition |
 
 ## Minimum Setup
 
-Most guides on this site require the same core tools. Set them up once here and every
-guide will reference back to this page rather than repeating the steps.
+Set up these tools once - every guide references back here rather than repeating the steps.
 
 **Required for all guides:**
 
 - [Workstation Setup](./workstation-setup.md) - VS Code, Git, GitHub CLI, Docker Desktop
 
-**Required for Docker-based guides** (most labs and some advanced guides):
+**Required for labs:**
 
 - [Traefik Reverse Proxy](./traefik.md) - Named local URLs instead of port numbers
   (e.g., `my-gw.localtest.me` instead of `localhost:9088`)
 
-## Where to Start
+## Learning Pathways
 
-**New to Git and version control?**
-Start with the [Hands-On Lab](../labs/git-ignition-lab.md). It walks you through a complete
-workflow from cloning to merging a pull request, with explanations along the way.
+Pathways are named by what you are learning, not by skill level. Each pathway ends with a lab before the next one begins. If you already know the topic, skip the guide and jump straight to the lab to verify - or skip the pathway entirely and enter at the next one.
 
-**Know Git but new to Ignition + Docker workflows?**
-Read the [Version Control Guide](../guides/version-control/intro.md) for context, then
-jump to the lab.
+```mermaid
+flowchart TD
+    WS["Workstation Setup"]
+    TR["Traefik\n(required for labs)"]
+
+    WS --> TR
+    WS --> FOUNDATIONS
+
+    subgraph FOUNDATIONS ["Foundations"]
+        direction TB
+        FG["Version Control"]
+        FL["Lab"]
+        FG --> FL
+    end
+
+    subgraph CONTAINERIZATION ["Containerization"]
+        direction TB
+        CG["Docker & Compose"]
+        CL["Lab"]
+        CG --> CL
+    end
+
+    TR --> FL
+    FL --> CONTAINERIZATION
+    TR --> CL
+```
+
+**Foundations** covers Git, GitHub, and version control workflows for Ignition projects. Start here if you are new to tracking Ignition configuration in source control.
+
+**Containerization** covers Docker Compose, the project-template architecture, licensing, and day-to-day gateway operations. Start here if you are comfortable with Git but new to running Ignition in containers.

--- a/docs/getting-started/traefik.md
+++ b/docs/getting-started/traefik.md
@@ -18,10 +18,10 @@ When you are running multiple Ignition gateways locally (common in more advanced
 managing port numbers gets messy fast. Traefik solves this by listening on port 80 and
 routing requests by hostname.
 
-:::note Not required for the basic version control lab
-The [Version Control Lab](../labs/version-control-lab.md) uses `localhost:8088` directly and does
-not require Traefik. This setup becomes useful when running multiple gateways or following
-guides that reference `.localtest.me` URLs.
+:::note Required for the labs
+The [Docker Lab](../labs/docker-ignition-lab.md) and [Version Control Lab](../labs/version-control-lab.md)
+both reach the gateway at `https://<GATEWAY_NAME>.localtest.me`, which requires Traefik to
+route the hostname to the right container.
 :::
 
 ## How It Works

--- a/docs/getting-started/traefik.md
+++ b/docs/getting-started/traefik.md
@@ -19,7 +19,7 @@ managing port numbers gets messy fast. Traefik solves this by listening on port 
 routing requests by hostname.
 
 :::note Not required for the basic version control lab
-The [Hands-On Lab](../labs/git-ignition-lab.md) uses `localhost:8088` directly and does
+The [Version Control Lab](../labs/version-control-lab.md) uses `localhost:8088` directly and does
 not require Traefik. This setup becomes useful when running multiple gateways or following
 guides that reference `.localtest.me` URLs.
 :::

--- a/docs/getting-started/workstation-setup.md
+++ b/docs/getting-started/workstation-setup.md
@@ -129,7 +129,104 @@ Winget is the official package manager for Windows. Homebrew is a package manage
 
 More information: [GitHub Quickstart](https://docs.github.com/en/get-started/quickstart/set-up-git)
 
+## kubectl
+
+Required for the Orchestration pathway. `kubectl` is the command-line tool for interacting with Kubernetes clusters.
+
+:::tip Already installed?
+Run `kubectl version --client` to confirm.
+:::
+
+**Download:**
+
+- macOS (Homebrew)
+
+  ```shell
+  brew install kubectl
+  ```
+
+- Windows (Winget)
+
+  ```shell
+  winget install -e --id Kubernetes.kubectl
+  ```
+
+- [Direct Download](https://kubernetes.io/docs/tasks/tools/)
+
+## Helm
+
+Required for the Orchestration pathway. Helm is the package manager for Kubernetes.
+
+:::tip Already installed?
+Run `helm version` to confirm.
+:::
+
+**Download:**
+
+- macOS (Homebrew)
+
+  ```shell
+  brew install helm
+  ```
+
+- Windows (Winget)
+
+  ```shell
+  winget install -e --id Helm.Helm
+  ```
+
+- [Direct Download](https://helm.sh/docs/intro/install/)
+
+## Terraform
+
+Required for the Orchestration pathway. Terraform provisions infrastructure declaratively.
+
+:::tip Already installed?
+Run `terraform version` to confirm.
+:::
+
+**Download:**
+
+- macOS (Homebrew)
+
+  ```shell
+  brew tap hashicorp/tap
+  brew install hashicorp/tap/terraform
+  ```
+
+- Windows (Winget)
+
+  ```shell
+  winget install -e --id Hashicorp.Terraform
+  ```
+
+- [Direct Download](https://developer.hashicorp.com/terraform/install)
+
+## kind
+
+Required for the Orchestration pathway. kind (Kubernetes in Docker) runs local Kubernetes clusters inside Docker containers. Terraform manages kind clusters in the labs, but the kind CLI is useful for inspecting cluster state.
+
+:::tip Already installed?
+Run `kind version` to confirm.
+:::
+
+**Download:**
+
+- macOS (Homebrew)
+
+  ```shell
+  brew install kind
+  ```
+
+- Windows (Winget)
+
+  ```shell
+  winget install -e --id Kubernetes.kind
+  ```
+
+- [Direct Download](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
 ## Windows Users
 
 If you are on Windows, review [Windows Setup Notes](./windows-setup.md)
-for Git line-ending configuration and long-path settings.
+for Git line-ending configuration and long-path settings. For the Orchestration pathway, WSL2 is strongly recommended - kind and Terraform work most reliably in a Linux environment.

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -9,9 +9,9 @@ sidebar_position: 2
 - [Traefik Reverse Proxy](../../getting-started/traefik.md) must be set up and running before `docker compose up` will succeed.
 :::
 
-The [Project Template](https://github.com/ia-eknorr/project-template) defines four services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
+The [Project Template](https://github.com/ia-eknorr/project-template) defines three services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
 
-## The Four Services
+## The Three Services
 
 ### The `bootstrap` Service
 
@@ -75,31 +75,15 @@ Inside Docker's network, services reach each other by service name. The database
 
 The database data is stored in a named volume so it survives container restarts. Stopping and restarting the `db` service does not lose your data unless you explicitly remove the volume with `docker compose down -v`.
 
-### The `config-cleanup` Service
-
-`config-cleanup` exists entirely because of how Ignition 8.3 manages resource files.
-
-When the gateway starts, it reads configuration from `resource.json` files in the bind-mounted directories - the same files Git tracks. After reading them, Ignition writes back to those files with its own runtime metadata: internal IDs, timestamps, and other fields Ignition manages internally. This write-back happens automatically and silently. The result is that after every gateway start, `git status` shows dozens of modified files even though you changed nothing intentional.
-
-`config-cleanup` watches the bind-mounted configuration directories with `git diff` in a loop. When it sees a file modified, it immediately runs `git restore` to revert Ignition's write-back. The loop runs continuously while the gateway is running, so Ignition's automatic writes are reverted as fast as they are made.
-
-You will see `config-cleanup` listed as a running service in `docker ps`. It is doing its job silently in the background.
-
-:::note Why not just .gitignore the resource.json files?
-The `resource.json` files contain both runtime metadata (that Ignition writes automatically) and configuration (that you set intentionally). Ignoring them entirely would mean your configuration changes - the database connection you set up, the tag provider you configured - would not be tracked in Git. The config-cleanup approach preserves your intentional changes while discarding Ignition's automatic write-backs.
-:::
-
 ## The External `proxy` Network
 
-The `gateway` service is attached to an external Docker network named `proxy`. This is the network Traefik listens on. Traffic from a browser to `${GATEWAY_NAME}.localtest.me` enters Traefik, which forwards it across the `proxy` network to the gateway container.
+The `gateway` service is attached to an external Docker network named `proxy`. This network is created and managed by Traefik, which you set up in [Traefik Reverse Proxy](../../getting-started/traefik.md). Traffic from a browser to `${GATEWAY_NAME}.localtest.me` enters Traefik, which forwards it across the `proxy` network to the gateway container.
 
 If Traefik is not running when you run `docker compose up`, Docker will fail immediately with:
 
 ```text
 network proxy not found
 ```
-
-The `proxy` network is created when you start Traefik, not when you start the project. See [Traefik Reverse Proxy](../../getting-started/traefik.md) for setup instructions.
 
 The `db` service is not attached to the `proxy` network. It is only reachable from other services in the same compose project, on the internal network Docker creates automatically. Keeping the database off the proxy network means it is never reachable from a browser, even accidentally.
 
@@ -114,5 +98,9 @@ Docker Compose reads variables from a `.env` file in the project root and substi
 | `DB_PASSWORD` | PostgreSQL password |
 | `TZ` | Container timezone (e.g. `America/Los_Angeles`) - affects timestamps in Ignition logs and tag history |
 | `DEPLOYMENT_MODE` | Activates a named resource collection - `dev` by default (see [Gateway Resource Collections](../../reference/resource-collections.md)) |
+
+:::tip Full environment variable reference
+For the complete list of environment variables the Ignition image supports, see the [Platform Environment Variables reference](https://docs.inductiveautomation.com/docs/8.3/appendix/reference-pages/platform-environment-variables#environment-variables) in the Ignition 8.3 docs.
+:::
 
 `.env` is listed in `.gitignore` and will not be committed. Never remove it from `.gitignore` - it may contain database credentials. If you need to share default values with your team, edit `.env.example` instead.

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -62,7 +62,7 @@ environment:
 This tells Ignition to trust the `X-Forwarded-For` and `X-Forwarded-Proto` headers that Traefik adds to proxied requests. Without it, Ignition sees HTTP traffic arriving at port 80 (the internal container port) and generates redirect URLs using `http://` - even though Traefik is serving HTTPS externally. The gateway and Traefik end up in a redirect loop, and Perspective sessions fail.
 
 :::warning Perspective sessions will fail without this
-`gateway.useProxyForwardedHeader=true` and `-a ${GATEWAY_NAME}.localtest.me` must both be set correctly when running behind a reverse proxy. If either is missing or wrong, opening a Perspective project produces a `MissingGatewayAddressException` error. This was a known issue in pre-8.3.0 builds - if you see this on an older version, update before troubleshooting further.
+`gateway.useProxyForwardedHeader=true` and `-a ${GATEWAY_NAME}.localtest.me` must both be set correctly when running behind a reverse proxy. If either is missing or wrong, opening a Perspective project produces a `MissingGatewayAddressException` error.
 :::
 
 ### The `db` Service

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -1,0 +1,118 @@
+---
+sidebar_position: 2
+---
+
+# The Compose Architecture
+
+:::tip Before continuing
+- [Introduction to Docker for Ignition](./intro.md)
+- [Traefik Reverse Proxy](../../getting-started/traefik.md) must be set up and running before `docker compose up` will succeed.
+:::
+
+The `ia-eknorr/project-template` at [github.com/ia-eknorr/project-template](https://github.com/ia-eknorr/project-template) defines four services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
+
+## The Four Services
+
+### The `bootstrap` Service
+
+`bootstrap` runs once before the gateway starts. Its job is to prepare the `ignition-data` named volume so the gateway finds a properly initialized data directory on first boot.
+
+An empty named volume would cause the gateway to fail immediately. Ignition expects certain files to exist in its data directory (`gateway.xml_clean`, directory structure for modules, etc.) before it can initialize. The bootstrap service seeds the volume with Ignition's base files by copying them from the official image before the gateway process ever starts.
+
+Bootstrap also generates a deterministic UUID from the `GATEWAY_NAME` environment variable using `md5sum`. This matters for licensing: Ignition ties a license activation to the gateway's UUID. By deriving the UUID from a predictable input (the gateway name), the same gateway name always produces the same UUID. If the volume is lost and recreated, the UUID is the same and the license can be restored without contacting Inductive Automation.
+
+To avoid re-seeding on every start, bootstrap writes a `.ignition-seed-complete` sentinel file to the volume after its first run. On subsequent starts, it checks for that file and exits immediately. The `gateway` service uses `depends_on` with a `service_completed_successfully` condition, so it will not start until bootstrap exits cleanly.
+
+### The `gateway` Service
+
+`gateway` runs the official `inductiveautomation/ignition` image. The command arguments passed to the container determine almost everything about how the gateway behaves.
+
+```yaml
+command:
+  - "-n"
+  - "${GATEWAY_NAME}"
+  - "-m"
+  - "4096"
+  - "-h"
+  - "80"
+  - "-s"
+  - "443"
+  - "-a"
+  - "${GATEWAY_NAME}.localtest.me"
+  - "-Dignition.config.mode=${DEPLOYMENT_MODE:-dev}"
+```
+
+`-n $GATEWAY_NAME` sets the gateway name that appears in the Status page and the gateway network. It also becomes the container's hostname inside Docker's network.
+
+`-m 4096` sets the JVM heap size in megabytes. 4096 MB is 4 GB. Set this to roughly 85% of the memory you want to allocate to the gateway - leaving headroom for the JVM's off-heap usage. Too low and the gateway will crash under load; too high and you crowd out other containers.
+
+`-h 80 -s 443` sets the HTTP and HTTPS ports the gateway listens on inside the container. These are container-internal ports, not host ports. Traefik routes external traffic to these ports across the `proxy` network.
+
+`-a ${GATEWAY_NAME}.localtest.me` is the public address Ignition tells clients to connect to. This must exactly match the URL clients actually use to reach the gateway. Traefik routes `${GATEWAY_NAME}.localtest.me` to the container, and Ignition advertises that same address to Perspective clients. If these do not match, the gateway and the reverse proxy disagree about where clients should go.
+
+`-Dignition.config.mode=${DEPLOYMENT_MODE:-dev}` activates a named resource collection. When set to `dev`, Ignition loads configuration from the `dev/` resource directory in addition to `core/`. This is how environment-specific settings (database connection strings, tag provider configurations) are separated from shared configuration. See [Gateway Resource Collections](../../reference/resource-collections.md) for a full explanation.
+
+The gateway service also sets one JVM system property that is easy to miss:
+
+```yaml
+environment:
+  - GATEWAY_SYSTEM_PROPS=gateway.useProxyForwardedHeader=true
+```
+
+This tells Ignition to trust the `X-Forwarded-For` and `X-Forwarded-Proto` headers that Traefik adds to proxied requests. Without it, Ignition sees HTTP traffic arriving at port 80 (the internal container port) and generates redirect URLs using `http://` - even though Traefik is serving HTTPS externally. The gateway and Traefik end up in a redirect loop, and Perspective sessions fail.
+
+:::warning Perspective sessions will fail without this
+`gateway.useProxyForwardedHeader=true` and `-a ${GATEWAY_NAME}.localtest.me` must both be set correctly when running behind a reverse proxy. If either is missing or wrong, opening a Perspective project produces a `MissingGatewayAddressException` error. This was tracked as IGN-13832 and fixed in 8.3.0 - if you are on an older build, update before troubleshooting further.
+:::
+
+### The `db` Service
+
+`db` runs PostgreSQL with a healthcheck. Its purpose is to provide a persistent, network-accessible database for the Ignition gateway's external database connection.
+
+The `gateway` service uses `depends_on` with `condition: service_healthy` pointing at `db`. Docker evaluates the healthcheck before allowing the gateway to start. Without this ordering, the gateway might initialize its database connection before PostgreSQL is ready to accept connections, producing a connection error on first boot that requires a manual gateway restart.
+
+Inside Docker's network, services reach each other by service name. The database hostname is `db` - the name of the service in the compose file. The Ignition database connection resource stored at `services/ignition/config/resources/core/ignition/database-connection/db/` uses `db` as the JDBC hostname. This works because Docker's internal DNS resolves service names automatically within a compose project.
+
+The database data is stored in a named volume so it survives container restarts. Stopping and restarting the `db` service does not lose your data unless you explicitly remove the volume with `docker compose down -v`.
+
+### The `config-cleanup` Service
+
+`config-cleanup` exists entirely because of how Ignition 8.3 manages resource files.
+
+When the gateway starts, it reads configuration from `resource.json` files in the bind-mounted directories - the same files Git tracks. After reading them, Ignition writes back to those files with its own runtime metadata: internal IDs, timestamps, and other fields Ignition manages internally. This write-back happens automatically and silently. The result is that after every gateway start, `git status` shows dozens of modified files even though you changed nothing intentional.
+
+`config-cleanup` watches the bind-mounted configuration directories with `git diff` in a loop. When it sees a file modified, it immediately runs `git restore` to revert Ignition's write-back. The loop runs continuously while the gateway is running, so Ignition's automatic writes are reverted as fast as they are made.
+
+You will see `config-cleanup` listed as a running service in `docker ps`. It is doing its job silently in the background.
+
+:::note Why not just .gitignore the resource.json files?
+The `resource.json` files contain both runtime metadata (that Ignition writes automatically) and configuration (that you set intentionally). Ignoring them entirely would mean your configuration changes - the database connection you set up, the tag provider you configured - would not be tracked in Git. The config-cleanup approach preserves your intentional changes while discarding Ignition's automatic write-backs.
+:::
+
+## The External `proxy` Network
+
+The `gateway` service is attached to an external Docker network named `proxy`. This is the network Traefik listens on. Traffic from a browser to `${GATEWAY_NAME}.localtest.me` enters Traefik, which forwards it across the `proxy` network to the gateway container.
+
+If Traefik is not running when you run `docker compose up`, Docker will fail immediately with:
+
+```text
+network proxy not found
+```
+
+The `proxy` network is created when you start Traefik, not when you start the project. See [Traefik Reverse Proxy](../../getting-started/traefik.md) for setup instructions.
+
+The `db` service is not attached to the `proxy` network. It is only reachable from other services in the same compose project, on the internal network Docker creates automatically. Keeping the database off the proxy network means it is never reachable from a browser, even accidentally.
+
+## The `.env` File
+
+Docker Compose reads variables from a `.env` file in the project root and substitutes them into the compose file wherever `${VARIABLE}` appears. The template ships with `.env.example` containing placeholder values. Copy it to `.env` and fill in your values before running `docker compose up`.
+
+| Variable | Purpose |
+| --- | --- |
+| `GATEWAY_NAME` | Gateway display name, container hostname, and Traefik route - the gateway is accessible at `${GATEWAY_NAME}.localtest.me` |
+| `DB_USER` | PostgreSQL username for the Ignition database connection |
+| `DB_PASSWORD` | PostgreSQL password |
+| `TZ` | Container timezone (e.g. `America/Los_Angeles`) - affects timestamps in Ignition logs and tag history |
+| `DEPLOYMENT_MODE` | Activates a named resource collection - `dev` by default (see [Gateway Resource Collections](../../reference/resource-collections.md)) |
+
+`.env` is listed in `.gitignore` and will not be committed. Never remove it from `.gitignore` - it may contain database credentials. If you need to share default values with your team, edit `.env.example` instead.

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 - [Traefik Reverse Proxy](../../getting-started/traefik.md) must be set up and running before `docker compose up` will succeed.
 :::
 
-The `ia-eknorr/project-template` at [github.com/ia-eknorr/project-template](https://github.com/ia-eknorr/project-template) defines four services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
+The [Project Template](https://github.com/ia-eknorr/project-template) defines four services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
 
 ## The Four Services
 

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -5,8 +5,10 @@ sidebar_position: 2
 # The Compose Architecture
 
 :::tip Before continuing
+
 - [Introduction to Docker for Ignition](./intro.md)
 - [Traefik Reverse Proxy](../../getting-started/traefik.md) must be set up and running before `docker compose up` will succeed.
+
 :::
 
 The [Project Template](https://github.com/ia-eknorr/project-template) defines three services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -96,6 +96,8 @@ Docker Compose reads variables from a `.env` file in the project root and substi
 | `GATEWAY_NAME` | Gateway display name, container hostname, and Traefik route - the gateway is accessible at `${GATEWAY_NAME}.localtest.me` |
 | `DB_USER` | PostgreSQL username for the Ignition database connection |
 | `DB_PASSWORD` | PostgreSQL password |
+| `GATEWAY_ADMIN_USERNAME` | Username for the initial gateway admin login |
+| `GATEWAY_ADMIN_PASSWORD` | Password for the initial gateway admin login - change before the first start |
 | `TZ` | Container timezone (e.g. `America/Los_Angeles`) - affects timestamps in Ignition logs and tag history |
 | `DEPLOYMENT_MODE` | Activates a named resource collection - `dev` by default (see [Gateway Resource Collections](../../reference/resource-collections.md)) |
 

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -62,7 +62,7 @@ environment:
 This tells Ignition to trust the `X-Forwarded-For` and `X-Forwarded-Proto` headers that Traefik adds to proxied requests. Without it, Ignition sees HTTP traffic arriving at port 80 (the internal container port) and generates redirect URLs using `http://` - even though Traefik is serving HTTPS externally. The gateway and Traefik end up in a redirect loop, and Perspective sessions fail.
 
 :::warning Perspective sessions will fail without this
-`gateway.useProxyForwardedHeader=true` and `-a ${GATEWAY_NAME}.localtest.me` must both be set correctly when running behind a reverse proxy. If either is missing or wrong, opening a Perspective project produces a `MissingGatewayAddressException` error. This was tracked as IGN-13832 and fixed in 8.3.0 - if you are on an older build, update before troubleshooting further.
+`gateway.useProxyForwardedHeader=true` and `-a ${GATEWAY_NAME}.localtest.me` must both be set correctly when running behind a reverse proxy. If either is missing or wrong, opening a Perspective project produces a `MissingGatewayAddressException` error. This was a known issue in pre-8.3.0 builds - if you see this on an older version, update before troubleshooting further.
 :::
 
 ### The `db` Service

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -41,8 +41,8 @@ docker compose logs -f gateway
 
 When you see a line containing `Gateway successfully started`, the gateway is ready. Open `https://${GATEWAY_NAME}.localtest.me` in your browser and accept the self-signed certificate warning (or add the Traefik CA to your trusted roots).
 
-:::note Default credentials
-The default admin username is `admin` and password is `password`. Change these immediately in any shared or production environment.
+:::note Gateway login
+The gateway login is whatever you set via `GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD` in your `.env` file. To change either value, edit `.env` and restart the gateway with `docker compose up -d` (or `docker compose restart gateway`).
 :::
 
 ## Restarting the Gateway

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Day-Two Operations
 
-This guide covers everything you need to operate an Ignition gateway running in Docker after the initial setup. It assumes the gateway is already running from the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template).
+This guide covers everything you need to operate an Ignition gateway running in Docker after the initial setup. It assumes the gateway is already running from the [Project Template](https://github.com/ia-eknorr/project-template).
 
 :::tip Before continuing
 Read [The Compose Architecture](./compose-architecture.md) to understand how the services, volumes, and bind mounts fit together before running any of the commands below.

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -76,7 +76,7 @@ The bootstrap service re-seeds the volume on the next start.
 1. Open `docker-compose.yml` and update the image tag:
 
    ```yaml
-   image: inductiveautomation/ignition:8.3.7   # was 8.3.6
+   image: inductiveautomation/ignition:8.3.7   # was __IGNITION_VERSION__
    ```
 
 2. Pull the new image:

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -120,4 +120,4 @@ The gateway also writes logs to `/usr/local/bin/ignition/logs/` inside the conta
 
 ## Installing Third-Party Modules
 
-Third-party modules (MQTT Engine, Azure Injector, etc.) installed through the gateway UI do not survive a `docker compose down -v` reset. Two patterns for making modules permanent are covered in [Third-Party Modules in Containers](../../guides/advanced/third-party-modules.md) in the Orchestration pathway.
+Third-party modules (MQTT Engine, Azure Injector, etc.) installed through the gateway UI do not survive a `docker compose down -v` reset. Two patterns for making modules permanent (derived image and entrypoint wrapper) will be covered in the Orchestration pathway.

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -21,7 +21,6 @@ All commands run from the project directory - the folder that contains your `doc
 | `docker compose down -v` | Stop and remove containers AND delete all volumes (full reset) |
 | `docker compose ps` | Show running services and their status |
 | `docker compose logs -f gateway` | Stream gateway logs (Ctrl+C to stop) |
-| `docker compose logs -f config-cleanup` | Stream config-cleanup logs to confirm it is running |
 | `docker compose restart gateway` | Restart only the gateway (preserves the volume) |
 | `docker compose exec gateway bash` | Open a shell inside the running gateway container |
 | `docker compose pull` | Pull the latest version of all images (does not restart) |
@@ -33,7 +32,6 @@ When you run `docker compose up -d` for the first time against a fresh project-t
 1. `bootstrap` runs first: seeds the `ignition-data` volume, generates a UUID from `GATEWAY_NAME`, writes the sentinel file, then exits.
 2. `db` starts and passes its healthcheck (PostgreSQL ready to accept connections).
 3. `gateway` starts: Ignition initializes, reads the bind-mounted config from `services/ignition/config/resources/`, connects to the database, and loads projects from `services/ignition/projects/`.
-4. `config-cleanup` starts: begins watching the bind-mounted directories and reverting any in-container writes.
 
 The gateway takes 60-120 seconds to finish starting. Watch progress with:
 

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -85,18 +85,14 @@ The bootstrap service re-seeds the volume on the next start.
    docker compose pull
    ```
 
-3. Do a full reset and restart:
+3. Restart the stack:
 
    ```shell
-   docker compose down -v
+   docker compose down
    docker compose up -d
    ```
 
-4. If using a standard license, reactivate it from the gateway's **Config > Licensing** page after startup.
-
-:::danger Never mix version and volume
-Never start a new image version against an existing volume from a different version without a reset. Ignition's internal database schema changes between versions and an incompatible volume will leave the gateway in a broken state.
-:::
+The volume is preserved across the restart. Ignition reads the existing data directory on startup and applies any necessary migrations automatically.
 
 ## Getting a Shell in the Gateway
 

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 5
+---
+
+# Day-Two Operations
+
+This guide covers everything you need to operate an Ignition gateway running in Docker after the initial setup. It assumes the gateway is already running from the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template).
+
+:::tip Before continuing
+Read [The Compose Architecture](./compose-architecture.md) to understand how the services, volumes, and bind mounts fit together before running any of the commands below.
+:::
+
+## Common Operations
+
+All commands run from the project directory - the folder that contains your `docker-compose.yml` file.
+
+| Command | What it does |
+| --- | --- |
+| `docker compose up -d` | Start all services in the background |
+| `docker compose down` | Stop and remove containers (volume and data preserved) |
+| `docker compose down -v` | Stop and remove containers AND delete all volumes (full reset) |
+| `docker compose ps` | Show running services and their status |
+| `docker compose logs -f gateway` | Stream gateway logs (Ctrl+C to stop) |
+| `docker compose logs -f config-cleanup` | Stream config-cleanup logs to confirm it is running |
+| `docker compose restart gateway` | Restart only the gateway (preserves the volume) |
+| `docker compose exec gateway bash` | Open a shell inside the running gateway container |
+| `docker compose pull` | Pull the latest version of all images (does not restart) |
+
+## First-Start Commissioning
+
+When you run `docker compose up -d` for the first time against a fresh project-template clone, the services start in a defined order:
+
+1. `bootstrap` runs first: seeds the `ignition-data` volume, generates a UUID from `GATEWAY_NAME`, writes the sentinel file, then exits.
+2. `db` starts and passes its healthcheck (PostgreSQL ready to accept connections).
+3. `gateway` starts: Ignition initializes, reads the bind-mounted config from `services/ignition/config/resources/`, connects to the database, and loads projects from `services/ignition/projects/`.
+4. `config-cleanup` starts: begins watching the bind-mounted directories and reverting any in-container writes.
+
+The gateway takes 60-120 seconds to finish starting. Watch progress with:
+
+```shell
+docker compose logs -f gateway
+```
+
+When you see a line containing `Gateway successfully started`, the gateway is ready. Open `https://${GATEWAY_NAME}.localtest.me` in your browser and accept the self-signed certificate warning (or add the Traefik CA to your trusted roots).
+
+:::note Default credentials
+The default admin username is `admin` and password is `password`. Change these immediately in any shared or production environment.
+:::
+
+## Restarting the Gateway
+
+Two options depending on what you need:
+
+- `docker compose restart gateway` - restarts the gateway process without touching the volume. Use this after changing gateway configuration in the Designer or after a `.env` change that does not require a volume reset.
+- `docker compose down && docker compose up -d` - stops all services and starts them again. The volume is preserved. Use this for a clean restart of the full stack.
+
+## Resetting to a Clean State
+
+:::warning This deletes all gateway data
+`docker compose down -v` deletes the `ignition-data` volume. Any changes made inside the gateway - Designer changes that were not committed to git, installed modules, license activation - are permanently lost.
+:::
+
+Use a full reset when:
+
+- Upgrading to a new Ignition version
+- The gateway is in an unrecoverable state
+- Starting fresh for a clean lab environment
+
+```shell
+docker compose down -v
+docker compose up -d
+```
+
+The bootstrap service re-seeds the volume on the next start.
+
+## Upgrading the Ignition Version
+
+1. Open `docker-compose.yml` and update the image tag:
+
+   ```yaml
+   image: inductiveautomation/ignition:8.3.7   # was 8.3.6
+   ```
+
+2. Pull the new image:
+
+   ```shell
+   docker compose pull
+   ```
+
+3. Do a full reset and restart:
+
+   ```shell
+   docker compose down -v
+   docker compose up -d
+   ```
+
+4. If using a standard license, reactivate it from the gateway's **Config > Licensing** page after startup.
+
+:::danger Never mix version and volume
+Never start a new image version against an existing volume from a different version without a reset. Ignition's internal database schema changes between versions and an incompatible volume will leave the gateway in a broken state.
+:::
+
+## Getting a Shell in the Gateway
+
+```shell
+docker compose exec gateway bash
+```
+
+From inside the container you can inspect files, check the Ignition data directory at `/usr/local/bin/ignition/data/`, or run Ignition's command-line tools. Exit with `exit` or Ctrl+D.
+
+## Reading Gateway Logs
+
+Ignition writes structured logs. Follow them live:
+
+```shell
+docker compose logs -f gateway
+```
+
+Filter for errors only:
+
+```shell
+docker compose logs gateway | grep -i error
+```
+
+The gateway also writes logs to `/usr/local/bin/ignition/logs/` inside the container. These are not bind-mounted, so they live in the volume and are lost on a `down -v` reset.
+
+## Installing Third-Party Modules
+
+Third-party modules (MQTT Engine, Azure Injector, etc.) installed through the gateway UI do not survive a `docker compose down -v` reset. Two patterns for making modules permanent are covered in [Third-Party Modules in Containers](../../guides/advanced/third-party-modules.md) in the Orchestration pathway.

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -58,3 +58,10 @@ On first start, if the gateway finds no existing data in its data directory, it 
 Docker does not change how Ignition licensing works - it changes how licensing is stored and activated. The license is tied to the gateway's UUID, which is stored in the named volume. If the volume is deleted, the activation is lost and must be restored. The bootstrap service in the `ia-eknorr/project-template` generates a deterministic UUID from the gateway name so that activation can be recovered predictably.
 
 See [Licensing in Containers](./licensing.md) for the full picture before running a licensed gateway in Docker.
+
+## Further Reading
+
+These guides cover Docker through the lens of running Ignition. If you want to go deeper on Docker and Compose themselves:
+
+- [Docker Compose Documentation](https://docs.docker.com/compose/) - official reference for compose file syntax, commands, and concepts
+- [Docker Documentation](https://docs.docker.com/) - the broader Docker engine, images, networking, and storage

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -5,8 +5,10 @@ sidebar_position: 1
 # Introduction to Docker for Ignition
 
 :::tip Before continuing
+
 - [Workstation Setup](../../getting-started/workstation-setup.md) must be complete - Docker Desktop must be installed and running.
 - Familiarity with the [Version Control guide](../version-control/intro.md) is helpful but not required.
+
 :::
 
 Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the [Project Template](https://github.com/ia-eknorr/project-template).

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 1
+---
+
+# Introduction to Docker for Ignition
+
+:::tip Before continuing
+- [Workstation Setup](../../getting-started/workstation-setup.md) must be complete - Docker Desktop must be installed and running.
+- Familiarity with the [Version Control guide](../version-control/intro.md) is helpful but not required.
+:::
+
+Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the `ia-eknorr/project-template`.
+
+## What Docker Solves for Ignition Developers
+
+The most immediate benefit is running multiple Ignition versions simultaneously. If you support a client on 8.3.4 and another on 8.3.6, you can run both gateways on the same machine without any manual installer switching. Each gateway lives in its own container, on its own ports, behind its own Traefik route.
+
+Beyond version isolation, Docker gives every developer on a project an identical environment. The gateway a new team member starts on day one behaves the same as the one that has been running in a CI pipeline for six months. There is no "works on my machine" because the image and compose configuration define the environment completely.
+
+Networking between multiple gateways is handled by Traefik, the reverse proxy that routes `*.localtest.me` hostnames to the correct container. Each gateway gets a clean URL without port numbers - no more remembering whether the staging gateway is on port 8088 or 8089.
+
+Teardown and reset are also cleaner. Removing a gateway installed on a host requires uninstalling the service, deleting leftover files across several system directories, and sometimes rebooting. With Docker, `docker compose down -v` removes the containers and their volumes in seconds, and `docker compose up` starts fresh. Nothing persists on the host.
+
+## Containers vs. VMs: the Ignition Mental Model
+
+A virtual machine runs a complete operating system on top of a hypervisor. Starting a VM means booting a kernel, initializing services, and waiting for a full OS to come up - this is why Ignition VMs can take minutes to reach the gateway login screen.
+
+A container shares the host OS kernel. There is no second operating system to boot. The Ignition process inside a container starts the same Java runtime on the same kernel as everything else on your machine. Gateway startup time drops from minutes to seconds.
+
+From Ignition's perspective, nothing has changed. The gateway process runs exactly as it would on a Linux server - same Java runtime, same port bindings, same file paths. The gateway does not know or care that it is inside a container. The web interface is at port 8088, the modules load from the same paths, and scripting functions behave identically.
+
+The critical difference is filesystem lifetime. Everything written inside a container's filesystem is discarded when the container stops, unless it was written to a volume or bind mount. A fresh container is a fresh slate. For Ignition this matters a great deal - the gateway's internal database, installed modules, and license activation would all disappear between restarts if not explicitly configured to persist. The next section explains how volumes and bind mounts solve this.
+
+## Named Volumes vs. Bind Mounts: Why Ignition Needs Both
+
+Ignition's data falls into two categories that require different persistence strategies.
+
+A named volume is a storage area that Docker manages on your host filesystem at a path Docker controls. You give it a name (`ignition-data`) and Docker handles the rest. Named volumes are the right tool for Ignition's runtime state: the internal database, installed modules, certificates, and license activation. This data needs to survive container restarts, but you do not want it in Git. You do not edit the internal database directly and you do not want license activation files tracked in version control. Docker manages the path; you treat it as a black box that keeps Ignition running across restarts.
+
+A bind mount maps a specific directory on your machine into the container at a specific path. The directory exists on your machine, Git tracks it, and Docker makes it visible inside the container at runtime. This is how Git-tracked project files and gateway configuration get into the gateway. Your `services/ignition/projects/` directory on disk appears inside the container at the path Ignition reads projects from. When you edit a project file in your editor, Ignition sees the change immediately because it is reading from the same directory.
+
+Ignition needs both because the two categories of data have fundamentally different requirements. Runtime state should persist but must not be in Git. Project files and gateway configuration must be in Git but do not need Docker to manage their path. Named volumes cover the first category; bind mounts cover the second.
+
+## The Official `inductiveautomation/ignition` Image
+
+Inductive Automation publishes official Docker images at `inductiveautomation/ignition` on Docker Hub. Images are tagged by Ignition version:
+
+```text
+inductiveautomation/ignition:8.3.6
+```
+
+The image packages the same Ignition installer used for bare-metal deployments. The gateway inside the image is configured to accept command-line arguments and environment variables for headless operation - no installer wizard, no manual configuration screen. You pass the gateway name, port assignments, JVM memory, and other settings through the compose file.
+
+On first start, if the gateway finds no existing data in its data directory, it initializes a fresh gateway automatically. If data already exists (from a named volume that was seeded), the gateway loads that existing state instead. The `ia-eknorr/project-template` takes advantage of this by running a bootstrap service that seeds the named volume before the gateway starts, ensuring the gateway always finds a properly initialized data directory rather than starting completely cold. This is covered in detail in [The Compose Architecture](./compose-architecture.md).
+
+## Licensing in Containers
+
+Docker does not change how Ignition licensing works - it changes how licensing is stored and activated. The license is tied to the gateway's UUID, which is stored in the named volume. If the volume is deleted, the activation is lost and must be restored. The bootstrap service in the `ia-eknorr/project-template` generates a deterministic UUID from the gateway name so that activation can be recovered predictably.
+
+See [Licensing in Containers](./licensing.md) for the full picture before running a licensed gateway in Docker.

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -33,13 +33,9 @@ The critical difference is filesystem lifetime. Everything written inside a cont
 
 ## Named Volumes vs. Bind Mounts: Why Ignition Needs Both
 
-Ignition's data falls into two categories that require different persistence strategies.
+Ignition's data falls into two categories that need different persistence strategies. Named volumes handle runtime state (the internal database, installed modules, license activation) that must survive restarts but does not belong in Git. Bind mounts handle the git-tracked project files and gateway configuration that you edit in your repository.
 
-A named volume is a storage area that Docker manages on your host filesystem at a path Docker controls. You give it a name (`ignition-data`) and Docker handles the rest. Named volumes are the right tool for Ignition's runtime state: the internal database, installed modules, certificates, and license activation. This data needs to survive container restarts, but you do not want it in Git. You do not edit the internal database directly and you do not want license activation files tracked in version control. Docker manages the path; you treat it as a black box that keeps Ignition running across restarts.
-
-A bind mount maps a specific directory on your machine into the container at a specific path. The directory exists on your machine, Git tracks it, and Docker makes it visible inside the container at runtime. This is how Git-tracked project files and gateway configuration get into the gateway. Your `services/ignition/projects/` directory on disk appears inside the container at the path Ignition reads projects from. When you edit a project file in your editor, Ignition sees the change immediately because it is reading from the same directory.
-
-Ignition needs both because the two categories of data have fundamentally different requirements. Runtime state should persist but must not be in Git. Project files and gateway configuration must be in Git but do not need Docker to manage their path. Named volumes cover the first category; bind mounts cover the second.
+See [Volume Strategy](./volume-strategy.md) for the full breakdown of what lives where and why.
 
 ## The Official `inductiveautomation/ignition` Image
 

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 - Familiarity with the [Version Control guide](../version-control/intro.md) is helpful but not required.
 :::
 
-Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the `ia-eknorr/project-template`.
+Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the [Project Template](https://github.com/ia-eknorr/project-template).
 
 ## What Docker Solves for Ignition Developers
 
@@ -51,11 +51,11 @@ inductiveautomation/ignition:8.3.6
 
 The image packages the same Ignition installer used for bare-metal deployments. The gateway inside the image is configured to accept command-line arguments and environment variables for headless operation - no installer wizard, no manual configuration screen. You pass the gateway name, port assignments, JVM memory, and other settings through the compose file.
 
-On first start, if the gateway finds no existing data in its data directory, it initializes a fresh gateway automatically. If data already exists (from a named volume that was seeded), the gateway loads that existing state instead. The `ia-eknorr/project-template` takes advantage of this by running a bootstrap service that seeds the named volume before the gateway starts, ensuring the gateway always finds a properly initialized data directory rather than starting completely cold. This is covered in detail in [The Compose Architecture](./compose-architecture.md).
+On first start, if the gateway finds no existing data in its data directory, it initializes a fresh gateway automatically. If data already exists (from a named volume that was seeded), the gateway loads that existing state instead. The project-template takes advantage of this by running a bootstrap service that seeds the named volume before the gateway starts, ensuring the gateway always finds a properly initialized data directory rather than starting completely cold. This is covered in detail in [The Compose Architecture](./compose-architecture.md).
 
 ## Licensing in Containers
 
-Docker does not change how Ignition licensing works - it changes how licensing is stored and activated. The license is tied to the gateway's UUID, which is stored in the named volume. If the volume is deleted, the activation is lost and must be restored. The bootstrap service in the `ia-eknorr/project-template` generates a deterministic UUID from the gateway name so that activation can be recovered predictably.
+Docker does not change how Ignition licensing works - it changes how licensing is stored and activated. The license is tied to the gateway's UUID, which is stored in the named volume. If the volume is deleted, the activation is lost and must be restored. The bootstrap service in the project-template generates a deterministic UUID from the gateway name so that activation can be recovered predictably.
 
 See [Licensing in Containers](./licensing.md) for the full picture before running a licensed gateway in Docker.
 

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -13,7 +13,7 @@ Docker changes how you install, run, and share Ignition gateways. Instead of run
 
 ## What Docker Solves for Ignition Developers
 
-The most immediate benefit is running multiple Ignition versions simultaneously. If you support a client on 8.3.4 and another on 8.3.6, you can run both gateways on the same machine without any manual installer switching. Each gateway lives in its own container, on its own ports, behind its own Traefik route.
+The most immediate benefit is running multiple Ignition versions simultaneously. If you support a client on 8.3.4 and another on __IGNITION_VERSION__, you can run both gateways on the same machine without any manual installer switching. Each gateway lives in its own container, on its own ports, behind its own Traefik route.
 
 Beyond version isolation, Docker gives every developer on a project an identical environment. The gateway a new team member starts on day one behaves the same as the one that has been running in a CI pipeline for six months. There is no "works on my machine" because the image and compose configuration define the environment completely.
 
@@ -42,7 +42,7 @@ See [Volume Strategy](./volume-strategy.md) for the full breakdown of what lives
 Inductive Automation publishes official Docker images at `inductiveautomation/ignition` on Docker Hub. Images are tagged by Ignition version:
 
 ```text
-inductiveautomation/ignition:8.3.6
+inductiveautomation/ignition:__IGNITION_VERSION__
 ```
 
 The image packages the same Ignition installer used for bare-metal deployments. The gateway inside the image is configured to accept command-line arguments and environment variables for headless operation - no installer wizard, no manual configuration screen. You pass the gateway name, port assignments, JVM memory, and other settings through the compose file.

--- a/docs/guides/docker/licensing.md
+++ b/docs/guides/docker/licensing.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 4
+---
+
+# Licensing in Containers
+
+:::tip Before continuing
+Read [The Compose Architecture](./compose-architecture.md) before this page.
+:::
+
+Ignition licensing works the same way in Docker as on bare metal: the gateway checks in with Inductive Automation's servers and stores activation state locally. What changes in Docker is where that state is stored and what counts as the "system identity" the license is tied to. Getting this wrong means losing your license activation every time you update the image.
+
+### License types
+
+**Standard license (6-character key):**
+
+- Tied to a "system identity" computed from hardware characteristics
+- In Docker, this identity is derived from the `ignition-data` named volume contents - not the host machine hardware
+- Activated online once, then works offline indefinitely
+- The license persists across container restarts and image updates as long as the named volume is preserved
+- `docker compose down -v` deletes the volume and the license activation - the gateway will be in trial mode on next start
+- Changing to a new image tag (e.g., `8.3.6` to `8.3.7`) can change the system identity and invalidate the license, requiring reactivation
+
+**Leased license (8-character key):**
+
+- Designed for dynamic environments like containers and cloud deployments
+- Checks in with IA servers every hour to renew the lease
+- If the gateway cannot reach IA's servers for 48 hours, it reverts to trial mode automatically
+- Not suitable for air-gapped or offline networks
+- Passed to the container as environment variables (see below)
+- Does not depend on system identity - the license follows the activation token, not the hardware
+
+### Decision tree
+
+| Scenario | Recommended license type |
+| --- | --- |
+| Local development with internet access | Either - trial mode works fine for labs |
+| Cloud or Kubernetes deployment with internet | Leased (8-char) |
+| On-premises server with internet access | Either - standard for stability |
+| Air-gapped or OT network | Standard (6-char) only - activate once, then offline |
+| CI/CD or ephemeral containers | Leased, or trial mode if testing only |
+
+### Environment variables
+
+Leased licenses are passed to the container as environment variables. Add these to your `.env` file:
+
+```text
+IGNITION_LICENSE_KEY=XXXX-XXXX
+IGNITION_ACTIVATION_TOKEN=your-activation-token
+```
+
+:::warning
+Never commit your `.env` file. It should be listed in `.gitignore`. Your license key and activation token are credentials.
+:::
+
+For Kubernetes secrets - covered in the Orchestration pathway - use the `_FILE` variant to load credentials from a mounted secret:
+
+```text
+IGNITION_LICENSE_KEY_FILE=/run/secrets/license-key
+IGNITION_ACTIVATION_TOKEN_FILE=/run/secrets/activation-token
+```
+
+### What happens on image upgrade
+
+:::warning License reactivation after upgrades
+When you change the Ignition image tag in `docker-compose.yml` (e.g., from `8.3.6` to `8.3.7`), run `docker compose down -v` before `docker compose up`. Starting fresh avoids state incompatibilities between versions.
+
+For standard licenses: the new volume will have a new system identity. You will need to reactivate. Have your license key available before upgrading.
+
+For leased licenses: they are not tied to system identity, so they reactivate automatically on first start as long as internet access is available.
+
+Never run `docker compose up` with a new image tag against an existing volume from a different major version.
+:::
+
+### Air-gapped reality
+
+:::note Air-gapped deployments
+There is no Inductive Automation on-premises license server. If your network has no outbound internet access:
+
+- Standard licenses can be activated once online, then operate offline indefinitely
+- Leased licenses will revert to trial mode after 48 hours offline - they are not suitable for air-gapped environments
+- If initial online activation is not possible, contact Inductive Automation for offline activation procedures
+
+The Orchestration pathway covers air-gapped Kubernetes deployments in detail.
+:::
+
+### Trial mode in labs
+
+All labs on this site use Ignition's built-in trial mode. Trial mode gives full functionality for 2 hours. When the trial expires, reset it from the gateway's status page and continue. No license key is required to complete any lab.

--- a/docs/guides/docker/licensing.md
+++ b/docs/guides/docker/licensing.md
@@ -8,41 +8,13 @@ sidebar_position: 4
 Read [The Compose Architecture](./compose-architecture.md) before this page.
 :::
 
-Ignition licensing works the same way in Docker as on bare metal: the gateway checks in with Inductive Automation's servers and stores activation state locally. What changes in Docker is where that state is stored and what counts as the "system identity" the license is tied to. Getting this wrong means losing your license activation every time you update the image.
+For anything running in a container, use an 8-character leased license. Leased licenses are designed for dynamic environments where the gateway's system identity changes between restarts, image upgrades, and volume resets - all of which happen frequently with Docker.
 
-### License types
+Standard 6-character keys are tied to a system identity computed from the named volume contents, so a `docker compose down -v` or an image upgrade can invalidate the activation and require manual reactivation. Leased keys avoid this entirely.
 
-**Standard license (6-character key):**
+## Passing the License to the Container
 
-- Tied to a "system identity" computed from hardware characteristics
-- In Docker, this identity is derived from the `ignition-data` named volume contents - not the host machine hardware
-- Activated online once, then works offline indefinitely
-- The license persists across container restarts and image updates as long as the named volume is preserved
-- `docker compose down -v` deletes the volume and the license activation - the gateway will be in trial mode on next start
-- Changing to a new image tag (e.g., `8.3.6` to `8.3.7`) can change the system identity and invalidate the license, requiring reactivation
-
-**Leased license (8-character key):**
-
-- Designed for dynamic environments like containers and cloud deployments
-- Checks in with IA servers every hour to renew the lease
-- If the gateway cannot reach IA's servers for 48 hours, it reverts to trial mode automatically
-- Not suitable for air-gapped or offline networks
-- Passed to the container as environment variables (see below)
-- Does not depend on system identity - the license follows the activation token, not the hardware
-
-### Decision tree
-
-| Scenario | Recommended license type |
-| --- | --- |
-| Local development with internet access | Either - trial mode works fine for labs |
-| Cloud or Kubernetes deployment with internet | Leased (8-char) |
-| On-premises server with internet access | Either - standard for stability |
-| Air-gapped or OT network | Standard (6-char) only - activate once, then offline |
-| CI/CD or ephemeral containers | Leased, or trial mode if testing only |
-
-### Environment variables
-
-Leased licenses are passed to the container as environment variables. Add these to your `.env` file:
+Add these to your `.env` file:
 
 ```text
 IGNITION_LICENSE_KEY=XXXX-XXXX
@@ -50,40 +22,15 @@ IGNITION_ACTIVATION_TOKEN=your-activation-token
 ```
 
 :::warning
-Never commit your `.env` file. It should be listed in `.gitignore`. Your license key and activation token are credentials.
+`.env` is listed in `.gitignore` for a reason. Never commit it - your license key and activation token are credentials.
 :::
 
-For Kubernetes secrets - covered in the Orchestration pathway - use the `_FILE` variant to load credentials from a mounted secret:
+For Kubernetes Secrets (covered in the Orchestration pathway), use the `_FILE` variant to load values from a mounted secret instead of plain env vars.
 
-```text
-IGNITION_LICENSE_KEY_FILE=/run/secrets/license-key
-IGNITION_ACTIVATION_TOKEN_FILE=/run/secrets/activation-token
-```
+## Trial Mode for Labs
 
-### What happens on image upgrade
+Every lab on this site runs in trial mode. Trial mode gives full functionality for 2 hours; reset it from the gateway's Status page when it expires. No license is required to complete any lab.
 
-:::warning License reactivation after upgrades
-When you change the Ignition image tag in `docker-compose.yml` (e.g., from `8.3.6` to `8.3.7`), run `docker compose down -v` before `docker compose up`. Starting fresh avoids state incompatibilities between versions.
+## Full Reference
 
-For standard licenses: the new volume will have a new system identity. You will need to reactivate. Have your license key available before upgrading.
-
-For leased licenses: they are not tied to system identity, so they reactivate automatically on first start as long as internet access is available.
-
-Never run `docker compose up` with a new image tag against an existing volume from a different major version.
-:::
-
-### Air-gapped reality
-
-:::note Air-gapped deployments
-There is no Inductive Automation on-premises license server. If your network has no outbound internet access:
-
-- Standard licenses can be activated once online, then operate offline indefinitely
-- Leased licenses will revert to trial mode after 48 hours offline - they are not suitable for air-gapped environments
-- If initial online activation is not possible, contact Inductive Automation for offline activation procedures
-
-The Orchestration pathway covers air-gapped Kubernetes deployments in detail.
-:::
-
-### Trial mode in labs
-
-All labs on this site use Ignition's built-in trial mode. Trial mode gives full functionality for 2 hours. When the trial expires, reset it from the gateway's status page and continue. No license key is required to complete any lab.
+For the complete licensing reference - activation flow, lease check-in intervals, edition selection - see the [Ignition 8.3 Licensing and Activation docs](https://docs.inductiveautomation.com/docs/8.3/platform/licensing-and-activation).

--- a/docs/guides/docker/licensing.md
+++ b/docs/guides/docker/licensing.md
@@ -27,6 +27,28 @@ IGNITION_ACTIVATION_TOKEN=your-activation-token
 
 For Kubernetes Secrets (covered in the Orchestration pathway), use the `_FILE` variant to load values from a mounted secret instead of plain env vars.
 
+## Release the Lease on Shutdown
+
+Leased activations are tracked server-side. If a container stops without releasing its lease, the activation can stay marked active on Inductive Automation's servers, preventing the same key from being used elsewhere until the lease expires. For Docker, where containers stop and start frequently, configure the gateway to release the lease cleanly on shutdown.
+
+Pass the property as a JVM argument after the `--` delimiter in your `command:` block in `docker-compose.yml`:
+
+```yaml
+command: >
+  -n ${GATEWAY_NAME}
+  -m 4096
+  -h 80
+  -s 443
+  -a ${GATEWAY_NAME}.localtest.me
+  --
+  -Dignition.license.leased-activation-terminate-sessions-on-shutdown=true
+```
+
+References:
+
+- [Leased Licensing Parameters](https://docs.inductiveautomation.com/docs/8.3/appendix/reference-pages/gateway-configuration-file-reference#leased-licensing-parameters) - the exact property and related timeout settings
+- [Supplemental JVM and Wrapper Arguments](https://docs.inductiveautomation.com/docs/8.3/platform/docker-image#supplemental-jvm-and-wrapper-arguments) - how the `--` delimiter passes JVM args to the gateway
+
 ## Trial Mode for Labs
 
 Every lab on this site runs in trial mode. Trial mode gives full functionality for 2 hours; reset it from the gateway's Status page when it expires. No license is required to complete any lab.

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 Read [The Compose Architecture](./compose-architecture.md) before this page.
 :::
 
-The project-template combines two storage mechanisms: a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
+The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms: a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
 Full reference: [Ignition 8.3 Version Control Guide - Curated Configuration Mounts (Additive Approach)](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach)
 

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 3
+---
+
+# The Additive Mount Strategy
+
+:::tip Before continuing
+Read [The Compose Architecture](./compose-architecture.md) before this page.
+:::
+
+Naive approaches to Docker + Ignition version control tend to fail in one of two directions: tracking too much, or too little. Mounting the entire `/data` directory captures license files, internal databases, certificates, and runtime state - none of which belong in Git. Mounting only `projects/` misses gateway configuration entirely, so connections, OPC-UA settings, and themes live outside version control. The additive mount strategy is Inductive Automation's recommended approach for Ignition 8.3 - it mounts only the specific subdirectories you want Git to track, layered on top of a named volume that holds everything else.
+
+Full reference: [Version Control Guide - Curated Configuration Mounts (Additive Approach)](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach)
+
+### What the named volume holds
+
+The `ignition-data` volume is managed by Docker and holds everything that should persist across restarts but should NOT be tracked in Git:
+
+- The internal SQLite/H2 database: alarm journal, tag history for short-term storage, audit log
+- Installed modules and their state
+- The Java keystore: TLS certificates, GAN certificates
+- License activation records
+- Logs
+- Anything Ignition writes at runtime
+
+The volume survives `docker compose down` but is deleted by `docker compose down -v`. Think of it as Ignition's installed files - analogous to what lives under `C:\Program Files\Inductive Automation\Ignition\data` on a Windows host install.
+
+### What the bind mounts hold
+
+Three directories from your repository are mounted into the container on top of the volume:
+
+| Repository path | Container path | What it contains |
+| --- | --- | --- |
+| `services/ignition/projects/` | `/data/projects/` | Ignition projects: Perspective views, tags, scripts, etc. |
+| `services/ignition/config/resources/core/` | `/data/config/resources/core/` | Shared gateway config: database connections, OPC-UA settings, themes, etc. |
+| `services/ignition/config/resources/dev/` | `/data/config/resources/dev/` | Dev environment overrides: dev database URL, dev tag provider, etc. |
+
+Git only sees these three directories. Everything else in the container lives in the volume and is invisible to Git.
+
+### Why "additive"
+
+The bind mounts layer on top of the named volume at the same path. If a file exists in the volume at `/data/config/resources/core/ignition/database-connection/db/resource.json`, the bind mount at `/data/config/resources/core/` makes the repository's version of that file take precedence. The volume provides the base; the bind mounts add and override specific paths.
+
+In practice this means:
+
+- First start: the volume is seeded by the bootstrap process, then bind mounts layer on top
+- Subsequent starts: the volume already exists, bind mounts apply on top again
+- `git pull` with new config files: immediately visible to the running gateway on next restart
+
+No container rebuild is required when you add or change files in the mounted directories. The gateway reads them from the host filesystem on startup.
+
+### Why you cannot mount `/data` directly
+
+:::danger
+Mounting a fresh empty volume - or an empty host directory - at `/data` causes `CrashLoopBackOff`. The Ignition container expects certain files to already exist at startup (`gateway.xml_clean`, `metro-keystore`, etc.). An empty mount hides the files that the container image itself provides, and the gateway cannot start.
+
+This is the most common cause of immediate container crashes when running Ignition on Kubernetes without an init container. The project-template avoids this entirely by mounting only subdirectories, leaving the top-level `/data` structure from the image's own filesystem intact.
+:::
+
+### Resource collections and deployment modes
+
+The `config/resources/` directory supports multiple named collections as subdirectories. The JVM argument `-Dignition.config.mode=dev` activates the `dev` collection. Both `core` and `dev` are active simultaneously when the gateway starts: `core` applies to all environments, `dev` overrides or supplements it for local development.
+
+```text
+services/ignition/config/resources/
+├── core/          # applies to all environments
+│   └── ignition/
+│       └── database-connection/db/   # shared DB config
+└── dev/           # applies when DEPLOYMENT_MODE=dev
+    └── ignition/
+        └── database-connection/db/   # dev-specific DB URL override
+```
+
+Adding a production environment means creating `services/ignition/config/resources/prod/`, adding a bind mount for it in `docker-compose.yml`, and setting `DEPLOYMENT_MODE=prod` in the environment. See [Gateway Resource Collections](../../reference/resource-collections.md) for the full reference.

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -8,9 +8,7 @@ sidebar_position: 3
 Read [The Compose Architecture](./compose-architecture.md) before this page.
 :::
 
-The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms: a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
-
-This is based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations).
+The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations): a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
 ### What the named volume holds
 

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -2,15 +2,15 @@
 sidebar_position: 3
 ---
 
-# The Additive Mount Strategy
+# Volumes and Bind Mounts
 
 :::tip Before continuing
 Read [The Compose Architecture](./compose-architecture.md) before this page.
 :::
 
-Naive approaches to Docker + Ignition version control tend to fail in one of two directions: tracking too much, or too little. Mounting the entire `/data` directory captures license files, internal databases, certificates, and runtime state - none of which belong in Git. Mounting only `projects/` misses gateway configuration entirely, so connections, OPC-UA settings, and themes live outside version control. The additive mount strategy is Inductive Automation's recommended approach for Ignition 8.3 - it mounts only the specific subdirectories you want Git to track, layered on top of a named volume that holds everything else.
+The project-template combines two storage mechanisms: a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
-Full reference: [Version Control Guide - Curated Configuration Mounts (Additive Approach)](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach)
+Full reference: [Ignition 8.3 Version Control Guide - Curated Configuration Mounts (Additive Approach)](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach)
 
 ### What the named volume holds
 
@@ -37,9 +37,9 @@ Three directories from your repository are mounted into the container on top of 
 
 Git only sees these three directories. Everything else in the container lives in the volume and is invisible to Git.
 
-### Why "additive"
+### How the layering works
 
-The bind mounts layer on top of the named volume at the same path. If a file exists in the volume at `/data/config/resources/core/ignition/database-connection/db/resource.json`, the bind mount at `/data/config/resources/core/` makes the repository's version of that file take precedence. The volume provides the base; the bind mounts add and override specific paths.
+The bind mounts apply on top of the named volume at the same path. If a file exists in the volume at `/data/config/resources/core/ignition/database-connection/db/resource.json`, the bind mount at `/data/config/resources/core/` makes the repository's version of that file take precedence. The volume provides the base; the bind mounts add and override specific paths.
 
 In practice this means:
 

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -10,7 +10,7 @@ Read [The Compose Architecture](./compose-architecture.md) before this page.
 
 The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms: a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
-Full reference: [Ignition 8.3 Version Control Guide - Curated Configuration Mounts (Additive Approach)](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#curated-configuration-mounts-additive-approach)
+This is based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations).
 
 ### What the named volume holds
 

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -10,7 +10,7 @@ Read [The Compose Architecture](./compose-architecture.md) before this page.
 
 The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations): a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
-### What the named volume holds
+## What the named volume holds
 
 The `ignition-data` volume is managed by Docker and holds everything that should persist across restarts but should NOT be tracked in Git:
 
@@ -23,7 +23,7 @@ The `ignition-data` volume is managed by Docker and holds everything that should
 
 The volume survives `docker compose down` but is deleted by `docker compose down -v`. Think of it as Ignition's installed files - analogous to what lives under `C:\Program Files\Inductive Automation\Ignition\data` on a Windows host install.
 
-### What the bind mounts hold
+## What the bind mounts hold
 
 Three directories from your repository are mounted into the container on top of the volume:
 
@@ -35,7 +35,7 @@ Three directories from your repository are mounted into the container on top of 
 
 Git only sees these three directories. Everything else in the container lives in the volume and is invisible to Git.
 
-### How the layering works
+## How the layering works
 
 The bind mounts apply on top of the named volume at the same path. If a file exists in the volume at `/data/config/resources/core/ignition/database-connection/db/resource.json`, the bind mount at `/data/config/resources/core/` makes the repository's version of that file take precedence. The volume provides the base; the bind mounts add and override specific paths.
 
@@ -47,7 +47,7 @@ In practice this means:
 
 No container rebuild is required when you add or change files in the mounted directories. The gateway reads them from the host filesystem on startup.
 
-### Why you cannot mount `/data` directly
+## Why you cannot mount `/data` directly
 
 :::danger
 Mounting a fresh empty volume - or an empty host directory - at `/data` causes `CrashLoopBackOff`. The Ignition container expects certain files to already exist at startup (`gateway.xml_clean`, `metro-keystore`, etc.). An empty mount hides the files that the container image itself provides, and the gateway cannot start.
@@ -55,7 +55,7 @@ Mounting a fresh empty volume - or an empty host directory - at `/data` causes `
 This is the most common cause of immediate container crashes when running Ignition on Kubernetes without an init container. The project-template avoids this entirely by mounting only subdirectories, leaving the top-level `/data` structure from the image's own filesystem intact.
 :::
 
-### Resource collections and deployment modes
+## Resource collections and deployment modes
 
 The `config/resources/` directory supports multiple named collections as subdirectories. The JVM argument `-Dignition.config.mode=dev` activates the `dev` collection. Both `core` and `dev` are active simultaneously when the gateway starts: `core` applies to all environments, `dev` overrides or supplements it for local development.
 

--- a/docs/guides/version-control/intro.md
+++ b/docs/guides/version-control/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Basics of Git
 
-A quick-reference page for Git concepts and commands used throughout this guide. If you're new to Git, start with the [Hands-On Lab](../../labs/git-ignition-lab.md) for a guided walkthrough before using these pages as reference.
+A quick-reference page for Git concepts and commands used throughout this guide. If you're new to Git, start with the [Version Control Lab](../../labs/version-control-lab.md) for a guided walkthrough before using these pages as reference.
 
 :::tip Before continuing
 Make sure [Workstation Setup](../../getting-started/workstation-setup.md) is complete before

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Step-by-step reference guides for working with Ignition in a professional develo
 
 Hands-on labs that walk through real Ignition workflows end to end.
 
-- [Git + Ignition Lab](./labs/git-ignition-lab.md) - Set up version control for an Ignition project from scratch using Docker and GitHub.
+- [Version Control Lab](./labs/version-control-lab.md) - Set up version control for an Ignition project from scratch using Docker and GitHub.
 
 ### Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,12 +20,14 @@ Tools and setup required across all guides - set up once, referenced everywhere.
 
 Step-by-step reference guides for working with Ignition in a professional development environment.
 
+- [Docker](./guides/docker/intro.md) - Compose architecture, volume strategy, licensing, and day-two operations for the project-template.
 - [Version Control](./guides/version-control/intro.md) - Git workflows for Ignition projects: workstation setup, branching, pull requests, and more.
 
 ### Labs
 
 Hands-on labs that walk through real Ignition workflows end to end.
 
+- [Docker Lab](./labs/docker-ignition-lab.md) - Start an Ignition gateway from the project-template, watch each service boot, and practice day-two operations.
 - [Version Control Lab](./labs/version-control-lab.md) - Set up version control for an Ignition project from scratch using Docker and GitHub.
 
 ### Reference

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -109,8 +109,7 @@ Traefik generates a self-signed certificate for `*.localtest.me`. Your browser w
 
 Log in with your admin credentials. On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
 
-![Gateway status page showing the gateway name](/img/docker/gateway-status-name.png)
-{/* TODO: screenshot */}
+{/* TODO: screenshot - gateway status page showing gateway name */}
 
 **Traefik routes the `*.localtest.me` domain to the correct container based on the gateway name - no port numbers needed in the URL.** Without Traefik, you would need to expose host ports and use `http://localhost:8088`.
 
@@ -162,8 +161,7 @@ Launch the Designer from the gateway homepage:
 2. Log in with your admin credentials
 3. In the Tag Browser on the left, right-click on the tag provider and select **New Tag - Memory Tag**
 
-   ![Creating a new memory tag in the Tag Browser](/img/docker/new-memory-tag.png)
-   {/* TODO: screenshot */}
+   {/* TODO: screenshot - creating a new memory tag in the Tag Browser */}
 
 4. Name the tag `DockerLabTest` and set the **Data Type** to `Float`
 5. Click **OK** to create the tag
@@ -290,8 +288,7 @@ docker compose logs -f gateway
 
 Wait for `Gateway successfully started`, then open the Designer again and check the Tag Browser. The `DockerLabTest` tag is still there.
 
-![DockerLabTest tag visible in the Tag Browser after restart](/img/docker/dockerlabtest-tag-persistent.png)
-{/* TODO: screenshot */}
+{/* TODO: screenshot - DockerLabTest tag visible in Tag Browser after restart */}
 
 **The tag persists because it lives in `services/ignition/projects/` on your machine's filesystem - not inside the Docker volume.** Restarting the container does not touch bind-mounted files. The named volume holds runtime state (module caches, the database WAL); your project files live in git.
 

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -55,13 +55,12 @@ cp .env.example .env
 copy .env.example .env
 ```
 
-Open `.env` in your editor and set:
+Open `.env` in your editor and set `GATEWAY_NAME` to match your repository name (for example, `my-ignition-project`). This becomes the Traefik hostname - your gateway will be available at `https://my-ignition-project.localtest.me`. The default `DB_USER`, `DB_PASSWORD`, and `TZ` are fine for local development.
 
-- `GATEWAY_NAME` to match your repository name (e.g., `my-ignition-project`). This becomes the Traefik hostname - your gateway will be available at `https://my-ignition-project.localtest.me`.
-- `GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD` to the credentials you want for the gateway's admin user.
+Admin credentials are set the first time you load the gateway in your browser, through the commissioning wizard (see Step 3).
 
 :::note .env stays out of git
-`.env` is listed in `.gitignore` by default. Environment-specific values (gateway name, credentials) should never be committed. Share configuration through `.env.example` instead.
+`.env` is listed in `.gitignore` by default. Environment-specific values should never be committed. Share configuration through `.env.example` instead.
 :::
 
 ---
@@ -76,11 +75,12 @@ docker compose up -d
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose up -d",
-  "[+] Running 4/4",
-  " ✔ Network my-ignition-project_default  Created",
-  " ✔ Container my-ignition-project-db-1              Started",
-  " ✔ Container my-ignition-project-bootstrap-1       Started",
-  " ✔ Container my-ignition-project-gateway-1         Started"
+  "[+] Running 5/5",
+  " ✔ Network my-ignition-project_default          Created",
+  " ✔ Volume \"my-ignition-project_ignition-data\"  Created",
+  " ✔ Container my-ignition-project-bootstrap-1    Exited",
+  " ✔ Container db-my-ignition-project             Healthy",
+  " ✔ Container my-ignition-project                Started"
 ]} />
 
 **The startup order is not random - it is enforced by `depends_on` conditions in the compose file.** Here is what happens in sequence:
@@ -88,6 +88,8 @@ docker compose up -d
 1. `db` starts and begins its healthcheck loop (PostgreSQL is initializing)
 2. `bootstrap` starts, seeds the `ignition-data` volume with Ignition's base files, writes the `.ignition-seed-complete` sentinel file, and exits with code 0
 3. Once `bootstrap` exits successfully and `db` passes its healthcheck, `gateway` starts
+
+Compose surfaces this in the `up` output: bootstrap is reported as `Exited` (its successful end state) and db as `Healthy` before the gateway starts. The gateway container uses your `GATEWAY_NAME` directly (no `-1` suffix) because `docker-compose.yml` sets `container_name`.
 
 :::tip Bootstrap runs only once
 The sentinel file at `.ignition-seed-complete` inside the named volume is the key. On every subsequent `docker compose up`, bootstrap checks for that file, finds it, and exits immediately without re-seeding. The volume is only seeded on the very first start, or after a `docker compose down -v` wipes the volume.
@@ -107,31 +109,33 @@ Scan the output for these milestones:
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose logs -f gateway",
-  "gateway-1  | wrapper  | --> Wrapper Started as Console",
-  "gateway-1  | wrapper  | Launching a JVM...",
-  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:00:12 | Ignition Platform starting...",
-  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:00:45 | Loading modules...",
-  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:01:30 | Module 'com.inductiveautomation.perspective' loaded.",
-  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:01:58 | Gateway successfully started."
+  "my-ignition-project  | wrapper  | 2026/05/15 21:25:17 | --> Wrapper Started as Console",
+  "my-ignition-project  | wrapper  | 2026/05/15 21:25:18 | Launching a JVM...",
+  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:19 | I [IgnitionGateway               ] [21:25:19.001]: Starting Ignition 8.3.6 (b2026042713)",
+  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:19 | I [g.ModuleManager               ] [21:25:19.304]: Loading modules....",
+  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:27 | I [ModuleInstance                ] [21:25:27.282]: Starting up module 'com.inductiveautomation.perspective' v3.3.6 (b2026042713)... module-name=Perspective",
+  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:27 | I [IgnitionGateway               ] [21:25:27.450]: Gateway started in 8 seconds."
 ]} />
 
-Press `Ctrl+C` to stop following the logs once you see `Gateway successfully started`.
+Press `Ctrl+C` to stop following the logs once you see `Gateway started in N seconds.`.
 
-:::note Startup takes 60-120 seconds
-This is normal. Ignition loads every module (Vision, Perspective, Reporting, Alarm Notification, and more) during startup, and each module initializes against the database. A fresh start on modest hardware commonly takes 90 seconds. **Do not assume the gateway is broken if it has not appeared after 30 seconds.**
+:::note Startup takes 30-120 seconds
+This is normal. Ignition loads every module (Vision, Perspective, Reporting, Alarm Notification, and more) during startup, and each module initializes against the database. **Do not assume the gateway is broken if it has not appeared after 30 seconds.**
 :::
 
-Once the logs settle, confirm all three services are running:
+Once the logs settle, confirm all three services are accounted for. Pass `-a` so the exited bootstrap container shows up too:
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ docker compose ps",
-  "NAME                                   IMAGE                            COMMAND                  SERVICE          CREATED          STATUS                    PORTS",
-  "my-ignition-project-bootstrap-1        ghcr.io/ia-eknorr/bootstrap      \"/bootstrap.sh\"          bootstrap        2 minutes ago    Exited (0) 2 minutes ago",
-  "my-ignition-project-db-1               postgres:15                      \"docker-entrypoint.s…\"   db               2 minutes ago    Up 2 minutes (healthy)",
-  "my-ignition-project-gateway-1          inductiveautomation/ignition      \"/usr/local/bin/igni…\"   gateway          2 minutes ago    Up 2 minutes (healthy)"
+  "$ docker compose ps -a",
+  "NAME                          IMAGE                                COMMAND                  SERVICE     CREATED          STATUS                      PORTS",
+  "db-my-ignition-project        postgres:18.4                        \"docker-entrypoint.s…\"   db          2 minutes ago    Up 2 minutes (healthy)      5432/tcp",
+  "my-ignition-project           inductiveautomation/ignition:8.3.6   \"docker-entrypoint.s…\"   gateway     2 minutes ago    Up 2 minutes (healthy)      8088/tcp",
+  "my-ignition-project-bootstrap-1   inductiveautomation/ignition:8.3.6   \"/bin/bash /docker-b…\"   bootstrap   2 minutes ago    Exited (0) 2 minutes ago"
 ]} />
 
-**`bootstrap` showing `Exited (0)` is correct and expected.** It is a one-shot service that exits after completing its work. Every other service should show `Up`.
+**`bootstrap` showing `Exited (0)` is correct and expected.** It is a one-shot service that exits after completing its work, so it does not appear in `docker compose ps` without the `-a` flag.
+
+Notice that bootstrap uses the same `inductiveautomation/ignition:8.3.6` image as the gateway. It is not a separate prebuilt image - it is the standard Ignition image with a different entrypoint (`/docker-bootstrap.sh`) that runs the seed script and exits.
 
 ---
 
@@ -149,7 +153,13 @@ Replace `<GATEWAY_NAME>` with the value you set in your `.env` file (for example
 Traefik generates a self-signed certificate for `*.localtest.me`. Your browser will show a security warning. This is expected for local development - click **Advanced** and then **Proceed** (the exact wording varies by browser). You will not see this warning in a production deployment that uses a real certificate.
 :::
 
-Log in with the username and password you set in `.env` (`GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD`). On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
+On the first start, the gateway runs the commissioning wizard. Step through it:
+
+1. Accept the license agreement
+2. Set an admin username and password (you will use these for the rest of the lab)
+3. Select **Standard Edition** (or your licensed edition)
+
+After commissioning you will land on the gateway home page. On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
 
 {/* TODO: screenshot - gateway status page showing gateway name */}
 
@@ -167,24 +177,28 @@ docker compose logs bootstrap
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose logs bootstrap",
-  "bootstrap-1  | Checking for existing seed...",
-  "bootstrap-1  | No seed found. Seeding ignition-data volume...",
-  "bootstrap-1  | Copying base Ignition files...",
-  "bootstrap-1  | Generating deterministic UUID from gateway name: my-ignition-project",
-  "bootstrap-1  | UUID: a3f2c1d4-...",
-  "bootstrap-1  | Writing sentinel file...",
-  "bootstrap-1  | Seed complete. Exiting."
+  "bootstrap-1  | Seeding data for gateway...",
+  "bootstrap-1  | Generated UUID for gateway: 86373f58-6342-d977-f2eb-fc1fafb95be2",
+  "bootstrap-1  | Seeding complete for gateway.",
+  "bootstrap-1  | Bootstrap completed successfully."
 ]} />
+
+The bootstrap script copies the base Ignition data tree into the `ignition-data` volume, derives a UUID from `GATEWAY_NAME` (so the same name always produces the same UUID), writes the `.ignition-seed-complete` sentinel, and exits 0. On a second `docker compose up` you would instead see `Gateway already seeded, skipping...`.
 
 Peek inside the gateway container's data directory:
 
 ```shell
-docker compose exec gateway ls /usr/local/bin/ignition/data/
+docker compose exec gateway ls -a /usr/local/bin/ignition/data/
 ```
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ docker compose exec gateway ls /usr/local/bin/ignition/data/",
-  ".ignition-seed-complete  cache  config  db  logs  modules  projects  quarantine  temp  user-lib"
+  "$ docker compose exec gateway ls -a /usr/local/bin/ignition/data/",
+  ".  ..  .container-init.conf  .context.tmp  .gateway.xml.bak",
+  ".ignition-seed-complete  .redundancy.xml.bak  certificates",
+  "commissioning.json  config  db  email-profiles  gateway.xml",
+  "gateway.xml_clean  ignition.conf  init.properties.bak  jar-cache",
+  "log4j.properties  logback.xml  metricsdb  modules.json  projects",
+  "redundancy.xml  request  response  var"
 ]} />
 
 **The `.ignition-seed-complete` file is the sentinel that prevents bootstrap from re-seeding.** As long as this file exists inside the named volume, bootstrap will exit immediately on every subsequent start without touching anything.
@@ -201,13 +215,12 @@ Launch the Designer from the gateway homepage:
 
 1. Click **Launch Designer** on the gateway homepage
 2. Log in with your admin credentials
-3. In the Tag Browser on the left, right-click on the tag provider and select **New Tag - Memory Tag**
+3. Click **New Project**, name it `docker_lab` (or similar), and open it
+4. In the Project Browser, right-click **Views** and add a new view named `hello`
+5. Drag a **Label** component onto the view and change its text to something recognizable
+6. Save: **File - Save and Publish** (or `Ctrl+S`)
 
-   {/* TODO: screenshot - creating a new memory tag in the Tag Browser */}
-
-4. Name the tag `DockerLabTest` and set the **Data Type** to `Float`
-5. Click **OK** to create the tag
-6. Save: **File - Save Project** (or `Ctrl+S`)
+   {/* TODO: screenshot - new view in Perspective Designer */}
 
 Back in your terminal, run:
 
@@ -215,27 +228,30 @@ Back in your terminal, run:
 git status
 ```
 
+{/* TODO: capture real git status output - requires Designer GUI interaction. Expected format below mirrors the Version Control Lab. */}
+
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ git status",
   "On branch main",
   "Changes not staged for commit:",
   "  (use \"git add <file>...\" to update what will be committed)",
   "  (use \"git restore <file>...\" to discard changes in working directory)",
-  "        modified:   services/ignition/projects/<project-name>/com.inductiveautomation.taghistorian/allTagPaths/resource.json",
-  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
+  "        new file:   services/ignition/projects/docker_lab/project.json",
+  "        new file:   services/ignition/projects/docker_lab/com.inductiveautomation.perspective/views/hello/resource.json",
+  "        new file:   services/ignition/projects/docker_lab/com.inductiveautomation.perspective/views/hello/view.json",
   "",
   "no changes added to commit (use \"git add\" and/or \"git commit -a\")"
 ]} />
 
-**The tag file appeared in `services/ignition/projects/` the moment you saved in the Designer - no export step, no manual copy.** The bind mount means the Designer writes directly to the files Git tracks.
+**The view files appeared in `services/ignition/projects/` the moment you saved in the Designer - no export step, no manual copy.** The bind mount means the Designer writes directly to the files Git tracks.
 
 :::tip What you are seeing
-Ignition stores each tag definition as a file in the project directory. The `tag.json` file is the tag you just created. Git sees it immediately because the Designer wrote it to the bind-mounted directory on your machine's filesystem.
+Ignition stores each Perspective view as a pair: `resource.json` (metadata) and `view.json` (the view itself). Both are human-readable JSON, which is what makes them useful to track in Git.
 :::
 
 ---
 
-## Step 6: Commit Your Tag
+## Step 6: Commit Your View
 
 Stage only the projects directory:
 
@@ -243,35 +259,29 @@ Stage only the projects directory:
 git add services/ignition/projects/
 ```
 
-Confirm what is staged:
-
-<Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ git status",
-  "On branch main",
-  "Changes to be committed:",
-  "  (use \"git restore --staged <file>...\" to unstage)",
-  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
-  "",
-  "nothing to commit, working tree clean"
-]} />
-
-**This is the intended workflow: changes inside `projects/` represent intentional work that should be committed.**
-
-Commit:
+Confirm what is staged, then commit:
 
 ```shell
-git commit -m "add DockerLabTest memory tag"
+git commit -m "add docker_lab project with hello view"
 ```
+
+**This is the intended workflow: changes inside `projects/` represent intentional work that should be committed.**
 
 ---
 
 ## Step 7: Restart and Verify Persistence
 
-Restart the gateway to confirm the tag survives a restart:
+Restart the gateway to confirm the view survives a restart:
 
 ```shell
 docker compose restart gateway
 ```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose restart gateway",
+  "[+] Restarting 1/1",
+  " ✔ Container my-ignition-project  Started"
+]} />
 
 Follow the logs until the gateway is back up:
 
@@ -279,11 +289,11 @@ Follow the logs until the gateway is back up:
 docker compose logs -f gateway
 ```
 
-Wait for `Gateway successfully started`, then open the Designer again and check the Tag Browser. The `DockerLabTest` tag is still there.
+Wait for `Gateway started in N seconds.`, then open the Designer again and check the Project Browser. The `docker_lab` project and its `hello` view are still there.
 
-{/* TODO: screenshot - DockerLabTest tag visible in Tag Browser after restart */}
+{/* TODO: screenshot - docker_lab project visible in Designer after restart */}
 
-**The tag persists because it lives in `services/ignition/projects/` on your machine's filesystem - not inside the Docker volume.** Restarting the container does not touch bind-mounted files. The named volume holds runtime state (module caches, the database WAL); your project files live in git.
+**The view persists because it lives in `services/ignition/projects/` on your machine's filesystem - not inside the Docker volume.** Restarting the container does not touch bind-mounted files. The named volume holds runtime state (module caches, the internal database); your project files live in git.
 
 :::tip Restart vs. down/up
 `docker compose restart gateway` stops and restarts only the gateway container. The `ignition-data` volume and the database are untouched. Use this for day-to-day operations when you need the gateway to reload a changed module or pick up a gateway script change.
@@ -301,15 +311,15 @@ docker compose down -v
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose down -v",
-  "[+] Running 5/5",
-  " ✔ Container my-ignition-project-gateway-1         Removed",
-  " ✔ Container my-ignition-project-db-1              Removed",
-  " ✔ Container my-ignition-project-bootstrap-1       Removed",
-  " ✔ Volume my-ignition-project_ignition-data        Removed",
-  " ✔ Volume my-ignition-project_db-data              Removed"
+  "[+] Running 6/6",
+  " ✔ Container my-ignition-project              Removed",
+  " ✔ Container my-ignition-project-bootstrap-1  Removed",
+  " ✔ Container db-my-ignition-project           Removed",
+  " ✔ Volume my-ignition-project_ignition-data   Removed",
+  " ✔ Network my-ignition-project_default        Removed"
 ]} />
 
-The `-v` flag removes named volumes. The `ignition-data` volume (which held the seeded Ignition installation, module cache, and license activation) and the `db-data` volume (PostgreSQL data) are both gone.
+The `-v` flag removes named volumes. The `ignition-data` volume (which held the seeded Ignition installation, module cache, license activation, and the internal config database) is gone. The template's PostgreSQL service is not configured with a named volume, so its data is wiped along with the container itself.
 
 Start the stack again:
 
@@ -317,9 +327,9 @@ Start the stack again:
 docker compose up -d
 ```
 
-Wait for startup, then open the Designer. The `DockerLabTest` tag is still there.
+Wait for startup. The gateway runs commissioning again because the named volume is brand new, then you can open the Designer. The `docker_lab` project and its `hello` view are still there.
 
-**`down -v` deletes volumes but does not touch git-tracked files.** The bind-mounted `services/ignition/projects/` directory is on your machine's disk - Docker never owns it. When the gateway starts fresh, the bind mount re-applies your committed project files and the tag is back.
+**`down -v` deletes volumes but does not touch git-tracked files.** The bind-mounted `services/ignition/projects/` directory is on your machine's disk - Docker never owns it. When the gateway starts fresh, the bind mount re-applies your committed project files and the view is back.
 
 :::warning What `down -v` does delete
 The named volume holds things that cannot be recovered from git: module license activations, alarm journal history stored in the volume, and any runtime data not bound to a git-tracked directory. After a `down -v`, the gateway starts as if it were a brand-new installation - you may need to re-activate your license. Use `down -v` only when you intentionally want a clean slate.
@@ -333,7 +343,7 @@ On a production system, the named volume holds your alarm journal, transaction g
 
 ## What You Built
 
-You started a three-service Ignition stack from scratch, watched each service fulfill its role in the startup sequence, and made a change through the Designer and saw it appear immediately in git.
+You started a three-service Ignition stack from scratch, watched each service fulfill its role in the startup sequence, made a change through the Designer, and saw it appear immediately in git.
 
 You also verified the core architectural guarantee: **git-tracked files survive a full volume reset**. The bind-mounted `projects/` directory is not inside Docker's storage - it is on your filesystem, in your repository. Docker volumes hold runtime state; git holds configuration.
 
@@ -343,13 +353,13 @@ You also verified the core architectural guarantee: **git-tracked files survive 
 | --- | --- |
 | Start the stack | `docker compose up -d` |
 | Stream gateway logs | `docker compose logs -f gateway` |
-| Check all service states | `docker compose ps` |
+| Check all service states (including exited bootstrap) | `docker compose ps -a` |
 | Restart the gateway | `docker compose restart gateway` |
 | Full reset (delete volumes) | `docker compose down -v` |
 | Stage only project changes | `git add services/ignition/projects/` |
 
 ### Next steps
 
+- Continue to the [Version Control Lab](./version-control-lab.md) to build the full Git, branching, and pull request workflow on top of the gateway you just stood up
 - Read [The Compose Architecture](../guides/docker/compose-architecture.md) for a detailed walkthrough of every service, every flag, and why they are configured the way they are
 - Read [Volume Strategy](../guides/docker/volume-strategy.md) to understand the full picture of what lives in named volumes versus bind mounts
-- Continue to the Containerization lab for more advanced operations: custom module installation, gateway network setup, and multi-gateway compose stacks

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -1,0 +1,366 @@
+---
+sidebar_position: 2
+---
+
+# Docker Lab
+
+## Purpose
+
+By the end of this lab, you will have started an Ignition gateway from the project-template, understand what each Docker service does during startup, made changes through the Designer and observed what Git tracks, and practiced the most common day-two operations.
+
+## Before Getting Started
+
+Prerequisites:
+
+- [Version Control Lab](./version-control-lab.md) completed - you should have a project-template fork cloned locally and understand the git workflow
+- [Workstation Setup](../getting-started/workstation-setup.md) complete (Docker Desktop running)
+- [Traefik Reverse Proxy](../getting-started/traefik.md) set up and running
+- `.env` file created from `.env.example` in your project-template repository
+
+If you do not have a project-template repository yet, complete the [Version Control Lab](./version-control-lab.md) first.
+
+---
+
+## Step 1: Start the Stack
+
+From the root of your project-template repository, bring up all four services:
+
+```shell
+docker compose up -d
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose up -d",
+  "[+] Running 5/5",
+  " ✔ Network my-ignition-project_default  Created",
+  " ✔ Container my-ignition-project-db-1              Started",
+  " ✔ Container my-ignition-project-bootstrap-1       Started",
+  " ✔ Container my-ignition-project-gateway-1         Started",
+  " ✔ Container my-ignition-project-config-cleanup-1  Started"
+]} />
+
+**The startup order is not random - it is enforced by `depends_on` conditions in the compose file.** Here is what happens in sequence:
+
+1. `db` starts and begins its healthcheck loop (PostgreSQL is initializing)
+2. `bootstrap` starts, seeds the `ignition-data` volume with Ignition's base files, writes the `.ignition-seed-complete` sentinel file, and exits with code 0
+3. Once `bootstrap` exits successfully and `db` passes its healthcheck, `gateway` starts
+4. `config-cleanup` starts alongside the gateway and begins watching for Ignition write-backs
+
+:::tip Bootstrap runs only once
+The sentinel file at `.ignition-seed-complete` inside the named volume is the key. On every subsequent `docker compose up`, bootstrap checks for that file, finds it, and exits immediately without re-seeding. The volume is only seeded on the very first start, or after a `docker compose down -v` wipes the volume.
+:::
+
+---
+
+## Step 2: Watch the Gateway Start
+
+Stream the gateway logs:
+
+```shell
+docker compose logs -f gateway
+```
+
+Scan the output for these milestones:
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose logs -f gateway",
+  "gateway-1  | wrapper  | --> Wrapper Started as Console",
+  "gateway-1  | wrapper  | Launching a JVM...",
+  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:00:12 | Ignition Platform starting...",
+  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:00:45 | Loading modules...",
+  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:01:30 | Module 'com.inductiveautomation.perspective' loaded.",
+  "gateway-1  | INFO   | jvm 1    | 2026-05-11 10:01:58 | Gateway successfully started."
+]} />
+
+Press `Ctrl+C` to stop following the logs once you see `Gateway successfully started`.
+
+:::note Startup takes 60-120 seconds
+This is normal. Ignition loads every module (Vision, Perspective, Reporting, Alarm Notification, and more) during startup, and each module initializes against the database. A fresh start on modest hardware commonly takes 90 seconds. **Do not assume the gateway is broken if it has not appeared after 30 seconds.**
+:::
+
+Once the logs settle, confirm all four services are running:
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose ps",
+  "NAME                                   IMAGE                            COMMAND                  SERVICE          CREATED          STATUS                    PORTS",
+  "my-ignition-project-bootstrap-1        ghcr.io/ia-eknorr/bootstrap      \"/bootstrap.sh\"          bootstrap        2 minutes ago    Exited (0) 2 minutes ago",
+  "my-ignition-project-config-cleanup-1   ghcr.io/ia-eknorr/config-cleanup \"/cleanup.sh\"            config-cleanup   2 minutes ago    Up 2 minutes",
+  "my-ignition-project-db-1               postgres:15                      \"docker-entrypoint.s…\"   db               2 minutes ago    Up 2 minutes (healthy)",
+  "my-ignition-project-gateway-1          inductiveautomation/ignition      \"/usr/local/bin/igni…\"   gateway          2 minutes ago    Up 2 minutes (healthy)"
+]} />
+
+**`bootstrap` showing `Exited (0)` is correct and expected.** It is a one-shot service that exits after completing its work. Every other service should show `Up`.
+
+---
+
+## Step 3: Open the Gateway
+
+Open your browser and navigate to:
+
+```text
+https://<GATEWAY_NAME>.localtest.me
+```
+
+Replace `<GATEWAY_NAME>` with the value you set in your `.env` file (for example, `https://my-ignition-project.localtest.me`).
+
+:::note The self-signed certificate warning
+Traefik generates a self-signed certificate for `*.localtest.me`. Your browser will show a security warning. This is expected for local development - click **Advanced** and then **Proceed** (the exact wording varies by browser). You will not see this warning in a production deployment that uses a real certificate.
+:::
+
+Log in with your admin credentials. On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
+
+![Gateway status page showing the gateway name](/img/docker/gateway-status-name.png)
+{/* TODO: screenshot */}
+
+**Traefik routes the `*.localtest.me` domain to the correct container based on the gateway name - no port numbers needed in the URL.** Without Traefik, you would need to expose host ports and use `http://localhost:8088`.
+
+---
+
+## Step 4: Observe the Bootstrap Volume Seeding
+
+Now that the gateway is running, inspect what bootstrap did:
+
+```shell
+docker compose logs bootstrap
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose logs bootstrap",
+  "bootstrap-1  | Checking for existing seed...",
+  "bootstrap-1  | No seed found. Seeding ignition-data volume...",
+  "bootstrap-1  | Copying base Ignition files...",
+  "bootstrap-1  | Generating deterministic UUID from gateway name: my-ignition-project",
+  "bootstrap-1  | UUID: a3f2c1d4-...",
+  "bootstrap-1  | Writing sentinel file...",
+  "bootstrap-1  | Seed complete. Exiting."
+]} />
+
+Peek inside the gateway container's data directory:
+
+```shell
+docker compose exec gateway ls /usr/local/bin/ignition/data/
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose exec gateway ls /usr/local/bin/ignition/data/",
+  ".ignition-seed-complete  cache  config  db  logs  modules  projects  quarantine  temp  user-lib"
+]} />
+
+**The `.ignition-seed-complete` file is the sentinel that prevents bootstrap from re-seeding.** As long as this file exists inside the named volume, bootstrap will exit immediately on every subsequent start without touching anything.
+
+:::tip Why a deterministic UUID matters
+Bootstrap derives the gateway UUID from `GATEWAY_NAME` using `md5sum`. If you lose the named volume (for example, after `docker compose down -v`), the bootstrap service recreates it with the same UUID. Ignition's license is bound to that UUID, so a license activated on this gateway can be restored after a volume reset without contacting Inductive Automation.
+:::
+
+---
+
+## Step 5: Open the Designer and Make a Change
+
+Launch the Designer from the gateway homepage:
+
+1. Click **Launch Designer** on the gateway homepage
+2. Log in with your admin credentials
+3. In the Tag Browser on the left, right-click on the tag provider and select **New Tag - Memory Tag**
+
+   ![Creating a new memory tag in the Tag Browser](/img/docker/new-memory-tag.png)
+   {/* TODO: screenshot */}
+
+4. Name the tag `DockerLabTest` and set the **Data Type** to `Float`
+5. Click **OK** to create the tag
+6. Save: **File - Save Project** (or `Ctrl+S`)
+
+Back in your terminal, run:
+
+```shell
+git status
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ git status",
+  "On branch main",
+  "Changes not staged for commit:",
+  "  (use \"git add <file>...\" to update what will be committed)",
+  "  (use \"git restore <file>...\" to discard changes in working directory)",
+  "        modified:   services/ignition/projects/<project-name>/com.inductiveautomation.taghistorian/allTagPaths/resource.json",
+  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
+  "",
+  "no changes added to commit (use \"git add\" and/or \"git commit -a\")"
+]} />
+
+**The tag file appeared in `services/ignition/projects/` the moment you saved in the Designer - no export step, no manual copy.** The bind mount means the Designer writes directly to the files Git tracks.
+
+:::tip What you are seeing
+Ignition stores each tag definition as a file in the project directory. The `tag.json` file is the tag you just created. Git sees it immediately because the Designer wrote it to the bind-mounted directory on your machine's filesystem.
+:::
+
+---
+
+## Step 6: Observe the config-cleanup Service
+
+Run `git status` again and look for changes in the config directory:
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ git status",
+  "On branch main",
+  "Changes not staged for commit:",
+  "        modified:   services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
+  "        modified:   services/ignition/config/resources/core/ignition/tag-provider/default/resource.json",
+  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json"
+]} />
+
+The `resource.json` files in `services/ignition/config/` are showing as modified, but you did not change them intentionally. Those are Ignition's automatic write-backs - runtime metadata the gateway writes back into the config files after reading them.
+
+Wait 10-15 seconds, then run `git status` again:
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ git status",
+  "On branch main",
+  "Changes not staged for commit:",
+  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
+  "",
+  "no changes added to commit (use \"git add\" and/or \"git commit -a\")"
+]} />
+
+**The `resource.json` modifications in `config/` are gone - `config-cleanup` reverted them automatically.** Only your intentional change (the `DockerLabTest` tag) remains.
+
+Confirm in the logs:
+
+```shell
+docker compose logs config-cleanup
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose logs config-cleanup",
+  "config-cleanup-1  | Watching for Ignition write-backs...",
+  "config-cleanup-1  | Detected modification: services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
+  "config-cleanup-1  | Reverting: git restore services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
+  "config-cleanup-1  | Detected modification: services/ignition/config/resources/core/ignition/tag-provider/default/resource.json",
+  "config-cleanup-1  | Reverting: git restore services/ignition/config/resources/core/ignition/tag-provider/default/resource.json"
+]} />
+
+:::note Why this service exists
+Ignition 8.3 writes back to the same `resource.json` files it reads during startup. Without `config-cleanup`, every `git status` after a gateway start would show dozens of noisy modifications, making it impossible to tell which changes are intentional. `config-cleanup` runs `git restore` in a loop so those write-backs never accumulate. See [The Compose Architecture](../guides/docker/compose-architecture.md) for a full explanation.
+:::
+
+---
+
+## Step 7: Commit Your Tag
+
+Stage only the projects directory - not the config directory, which `config-cleanup` has already cleaned up:
+
+```shell
+git add services/ignition/projects/
+```
+
+Confirm what is staged:
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ git status",
+  "On branch main",
+  "Changes to be committed:",
+  "  (use \"git restore --staged <file>...\" to unstage)",
+  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
+  "",
+  "nothing to commit, working tree clean"
+]} />
+
+The `config/` files are not staged. **This is the intended workflow: changes inside `projects/` represent intentional work; the `config/` write-backs are noise that `config-cleanup` silently discards.**
+
+Commit:
+
+```shell
+git commit -m "add DockerLabTest memory tag"
+```
+
+---
+
+## Step 8: Restart and Verify Persistence
+
+Restart the gateway to confirm the tag survives a restart:
+
+```shell
+docker compose restart gateway
+```
+
+Follow the logs until the gateway is back up:
+
+```shell
+docker compose logs -f gateway
+```
+
+Wait for `Gateway successfully started`, then open the Designer again and check the Tag Browser. The `DockerLabTest` tag is still there.
+
+![DockerLabTest tag visible in the Tag Browser after restart](/img/docker/dockerlabtest-tag-persistent.png)
+{/* TODO: screenshot */}
+
+**The tag persists because it lives in `services/ignition/projects/` on your machine's filesystem - not inside the Docker volume.** Restarting the container does not touch bind-mounted files. The named volume holds runtime state (module caches, the database WAL); your project files live in git.
+
+:::tip Restart vs. down/up
+`docker compose restart gateway` stops and restarts only the gateway container. The `ignition-data` volume and the database are untouched. Use this for day-to-day operations when you need the gateway to reload a changed module or pick up a gateway script change.
+:::
+
+---
+
+## Step 9: Full Reset
+
+Run a full teardown with volume removal:
+
+```shell
+docker compose down -v
+```
+
+<Terminal title="bash — ~/my-ignition-project" lines={[
+  "$ docker compose down -v",
+  "[+] Running 6/6",
+  " ✔ Container my-ignition-project-config-cleanup-1  Removed",
+  " ✔ Container my-ignition-project-gateway-1         Removed",
+  " ✔ Container my-ignition-project-db-1              Removed",
+  " ✔ Container my-ignition-project-bootstrap-1       Removed",
+  " ✔ Volume my-ignition-project_ignition-data        Removed",
+  " ✔ Volume my-ignition-project_db-data              Removed"
+]} />
+
+The `-v` flag removes named volumes. The `ignition-data` volume (which held the seeded Ignition installation, module cache, and license activation) and the `db-data` volume (PostgreSQL data) are both gone.
+
+Start the stack again:
+
+```shell
+docker compose up -d
+```
+
+Wait for startup, then open the Designer. The `DockerLabTest` tag is still there.
+
+**`down -v` deletes volumes but does not touch git-tracked files.** The bind-mounted `services/ignition/projects/` directory is on your machine's disk - Docker never owns it. When the gateway starts fresh, the bind mount re-applies your committed project files and the tag is back.
+
+:::warning What `down -v` does delete
+The named volume holds things that cannot be recovered from git: module license activations, alarm journal history stored in the volume, and any runtime data not bound to a git-tracked directory. After a `down -v`, the gateway starts as if it were a brand-new installation - you may need to re-activate your license. Use `down -v` only when you intentionally want a clean slate.
+:::
+
+:::danger Never run `down -v` on a production gateway
+On a production system, the named volume holds your alarm journal, transaction group data, and other runtime state that is not tracked in git. A `docker compose down -v` on production is a destructive operation with no undo.
+:::
+
+---
+
+## What You Built
+
+You started a four-service Ignition stack from scratch, watched each service fulfill its role in the startup sequence, made a change through the Designer and saw it appear immediately in git, and observed `config-cleanup` silently discarding Ignition's automatic write-backs so your working tree stays clean.
+
+You also verified the core architectural guarantee: **git-tracked files survive a full volume reset**. The bind-mounted `projects/` directory is not inside Docker's storage - it is on your filesystem, in your repository. Docker volumes hold runtime state; git holds configuration.
+
+### The workflow you practiced
+
+| Action | Command |
+| --- | --- |
+| Start the stack | `docker compose up -d` |
+| Stream gateway logs | `docker compose logs -f gateway` |
+| Check all service states | `docker compose ps` |
+| Restart the gateway | `docker compose restart gateway` |
+| Full reset (delete volumes) | `docker compose down -v` |
+| Stage only project changes | `git add services/ignition/projects/` |
+
+### Next steps
+
+- Read [The Compose Architecture](../guides/docker/compose-architecture.md) for a detailed walkthrough of every service, every flag, and why they are configured the way they are
+- Read [Volume Strategy](../guides/docker/volume-strategy.md) to understand the full picture of what lives in named volumes versus bind mounts
+- Continue to the Containerization lab for more advanced operations: custom module installation, gateway network setup, and multi-gateway compose stacks

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -12,12 +12,12 @@ By the end of this lab, you will have started an Ignition gateway from the proje
 
 Prerequisites:
 
-- [Version Control Lab](./version-control-lab.md) completed - you should have a project-template fork cloned locally and understand the git workflow
+- [Version Control Lab](./version-control-lab.md) completed - you should have a repository created from project-template cloned locally and understand the git workflow
 - [Workstation Setup](../getting-started/workstation-setup.md) complete (Docker Desktop running)
 - [Traefik Reverse Proxy](../getting-started/traefik.md) set up and running
-- `.env` file created from `.env.example` in your project-template repository, with `GATEWAY_ADMIN_PASSWORD` (and optionally `GATEWAY_ADMIN_USERNAME`) set before bringing up the stack
+- `.env` file created from `.env.example` in your repository, with `GATEWAY_ADMIN_PASSWORD` (and optionally `GATEWAY_ADMIN_USERNAME`) set before bringing up the stack
 
-If you do not have a project-template repository yet, complete the [Version Control Lab](./version-control-lab.md) first.
+If you do not have a repository created from project-template yet, complete the [Version Control Lab](./version-control-lab.md) first.
 
 ---
 
@@ -144,8 +144,8 @@ docker compose exec gateway ls /usr/local/bin/ignition/data/
 
 **The `.ignition-seed-complete` file is the sentinel that prevents bootstrap from re-seeding.** As long as this file exists inside the named volume, bootstrap will exit immediately on every subsequent start without touching anything.
 
-:::tip Why a deterministic UUID matters
-Bootstrap derives the gateway UUID from `GATEWAY_NAME` using `md5sum`. If you lose the named volume (for example, after `docker compose down -v`), the bootstrap service recreates it with the same UUID. Ignition's license is bound to that UUID, so a license activated on this gateway can be restored after a volume reset without contacting Inductive Automation.
+:::tip Why deterministic UUIDs matter
+Ignition's license activation is tied to the gateway's UUID. Deriving it from `GATEWAY_NAME` means a recreated volume gets the same UUID and the license can be restored without reactivation. See [The bootstrap Service](../guides/docker/compose-architecture.md#the-bootstrap-service) for full details.
 :::
 
 ---

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -23,7 +23,7 @@ If you do not have a project-template repository yet, complete the [Version Cont
 
 ## Step 1: Start the Stack
 
-From the root of your project-template repository, bring up all four services:
+From the root of your project-template repository, bring up all three services:
 
 ```shell
 docker compose up -d
@@ -31,12 +31,11 @@ docker compose up -d
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose up -d",
-  "[+] Running 5/5",
+  "[+] Running 4/4",
   " ✔ Network my-ignition-project_default  Created",
   " ✔ Container my-ignition-project-db-1              Started",
   " ✔ Container my-ignition-project-bootstrap-1       Started",
-  " ✔ Container my-ignition-project-gateway-1         Started",
-  " ✔ Container my-ignition-project-config-cleanup-1  Started"
+  " ✔ Container my-ignition-project-gateway-1         Started"
 ]} />
 
 **The startup order is not random - it is enforced by `depends_on` conditions in the compose file.** Here is what happens in sequence:
@@ -44,7 +43,6 @@ docker compose up -d
 1. `db` starts and begins its healthcheck loop (PostgreSQL is initializing)
 2. `bootstrap` starts, seeds the `ignition-data` volume with Ignition's base files, writes the `.ignition-seed-complete` sentinel file, and exits with code 0
 3. Once `bootstrap` exits successfully and `db` passes its healthcheck, `gateway` starts
-4. `config-cleanup` starts alongside the gateway and begins watching for Ignition write-backs
 
 :::tip Bootstrap runs only once
 The sentinel file at `.ignition-seed-complete` inside the named volume is the key. On every subsequent `docker compose up`, bootstrap checks for that file, finds it, and exits immediately without re-seeding. The volume is only seeded on the very first start, or after a `docker compose down -v` wipes the volume.
@@ -78,13 +76,12 @@ Press `Ctrl+C` to stop following the logs once you see `Gateway successfully sta
 This is normal. Ignition loads every module (Vision, Perspective, Reporting, Alarm Notification, and more) during startup, and each module initializes against the database. A fresh start on modest hardware commonly takes 90 seconds. **Do not assume the gateway is broken if it has not appeared after 30 seconds.**
 :::
 
-Once the logs settle, confirm all four services are running:
+Once the logs settle, confirm all three services are running:
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose ps",
   "NAME                                   IMAGE                            COMMAND                  SERVICE          CREATED          STATUS                    PORTS",
   "my-ignition-project-bootstrap-1        ghcr.io/ia-eknorr/bootstrap      \"/bootstrap.sh\"          bootstrap        2 minutes ago    Exited (0) 2 minutes ago",
-  "my-ignition-project-config-cleanup-1   ghcr.io/ia-eknorr/config-cleanup \"/cleanup.sh\"            config-cleanup   2 minutes ago    Up 2 minutes",
   "my-ignition-project-db-1               postgres:15                      \"docker-entrypoint.s…\"   db               2 minutes ago    Up 2 minutes (healthy)",
   "my-ignition-project-gateway-1          inductiveautomation/ignition      \"/usr/local/bin/igni…\"   gateway          2 minutes ago    Up 2 minutes (healthy)"
 ]} />
@@ -193,58 +190,9 @@ Ignition stores each tag definition as a file in the project directory. The `tag
 
 ---
 
-## Step 6: Observe the config-cleanup Service
+## Step 6: Commit Your Tag
 
-Run `git status` again and look for changes in the config directory:
-
-<Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ git status",
-  "On branch main",
-  "Changes not staged for commit:",
-  "        modified:   services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
-  "        modified:   services/ignition/config/resources/core/ignition/tag-provider/default/resource.json",
-  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json"
-]} />
-
-The `resource.json` files in `services/ignition/config/` are showing as modified, but you did not change them intentionally. Those are Ignition's automatic write-backs - runtime metadata the gateway writes back into the config files after reading them.
-
-Wait 10-15 seconds, then run `git status` again:
-
-<Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ git status",
-  "On branch main",
-  "Changes not staged for commit:",
-  "        modified:   services/ignition/projects/<project-name>/tags/DockerLabTest/tag.json",
-  "",
-  "no changes added to commit (use \"git add\" and/or \"git commit -a\")"
-]} />
-
-**The `resource.json` modifications in `config/` are gone - `config-cleanup` reverted them automatically.** Only your intentional change (the `DockerLabTest` tag) remains.
-
-Confirm in the logs:
-
-```shell
-docker compose logs config-cleanup
-```
-
-<Terminal title="bash — ~/my-ignition-project" lines={[
-  "$ docker compose logs config-cleanup",
-  "config-cleanup-1  | Watching for Ignition write-backs...",
-  "config-cleanup-1  | Detected modification: services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
-  "config-cleanup-1  | Reverting: git restore services/ignition/config/resources/core/ignition/database-connection/db/resource.json",
-  "config-cleanup-1  | Detected modification: services/ignition/config/resources/core/ignition/tag-provider/default/resource.json",
-  "config-cleanup-1  | Reverting: git restore services/ignition/config/resources/core/ignition/tag-provider/default/resource.json"
-]} />
-
-:::note Why this service exists
-Ignition 8.3 writes back to the same `resource.json` files it reads during startup. Without `config-cleanup`, every `git status` after a gateway start would show dozens of noisy modifications, making it impossible to tell which changes are intentional. `config-cleanup` runs `git restore` in a loop so those write-backs never accumulate. See [The Compose Architecture](../guides/docker/compose-architecture.md) for a full explanation.
-:::
-
----
-
-## Step 7: Commit Your Tag
-
-Stage only the projects directory - not the config directory, which `config-cleanup` has already cleaned up:
+Stage only the projects directory:
 
 ```shell
 git add services/ignition/projects/
@@ -262,7 +210,7 @@ Confirm what is staged:
   "nothing to commit, working tree clean"
 ]} />
 
-The `config/` files are not staged. **This is the intended workflow: changes inside `projects/` represent intentional work; the `config/` write-backs are noise that `config-cleanup` silently discards.**
+**This is the intended workflow: changes inside `projects/` represent intentional work that should be committed.**
 
 Commit:
 
@@ -272,7 +220,7 @@ git commit -m "add DockerLabTest memory tag"
 
 ---
 
-## Step 8: Restart and Verify Persistence
+## Step 7: Restart and Verify Persistence
 
 Restart the gateway to confirm the tag survives a restart:
 
@@ -298,7 +246,7 @@ Wait for `Gateway successfully started`, then open the Designer again and check 
 
 ---
 
-## Step 9: Full Reset
+## Step 8: Full Reset
 
 Run a full teardown with volume removal:
 
@@ -308,8 +256,7 @@ docker compose down -v
 
 <Terminal title="bash — ~/my-ignition-project" lines={[
   "$ docker compose down -v",
-  "[+] Running 6/6",
-  " ✔ Container my-ignition-project-config-cleanup-1  Removed",
+  "[+] Running 5/5",
   " ✔ Container my-ignition-project-gateway-1         Removed",
   " ✔ Container my-ignition-project-db-1              Removed",
   " ✔ Container my-ignition-project-bootstrap-1       Removed",
@@ -341,7 +288,7 @@ On a production system, the named volume holds your alarm journal, transaction g
 
 ## What You Built
 
-You started a four-service Ignition stack from scratch, watched each service fulfill its role in the startup sequence, made a change through the Designer and saw it appear immediately in git, and observed `config-cleanup` silently discarding Ignition's automatic write-backs so your working tree stays clean.
+You started a three-service Ignition stack from scratch, watched each service fulfill its role in the startup sequence, and made a change through the Designer and saw it appear immediately in git.
 
 You also verified the core architectural guarantee: **git-tracked files survive a full volume reset**. The bind-mounted `projects/` directory is not inside Docker's storage - it is on your filesystem, in your repository. Docker volumes hold runtime state; git holds configuration.
 

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Docker Lab
@@ -12,12 +12,57 @@ By the end of this lab, you will have started an Ignition gateway from the proje
 
 Prerequisites:
 
-- [Version Control Lab](./version-control-lab.md) completed - you should have a repository created from project-template cloned locally and understand the git workflow
-- [Workstation Setup](../getting-started/workstation-setup.md) complete (Docker Desktop running)
+- [Workstation Setup](../getting-started/workstation-setup.md) complete (Docker Desktop running, Git installed)
 - [Traefik Reverse Proxy](../getting-started/traefik.md) set up and running
-- `.env` file created from `.env.example` in your repository, with `GATEWAY_ADMIN_PASSWORD` (and optionally `GATEWAY_ADMIN_USERNAME`) set before bringing up the stack
+- A GitHub account
 
-If you do not have a repository created from project-template yet, complete the [Version Control Lab](./version-control-lab.md) first.
+This lab is self-contained: you will create a repository from `project-template`, clone it, and configure `.env` in Step 0. If you have already done these steps as part of the [Version Control Lab](./version-control-lab.md), skip ahead to Step 1.
+
+---
+
+## Step 0: Create Your Project
+
+The [`ia-eknorr/project-template`](https://github.com/ia-eknorr/project-template) repository
+is a pre-configured Ignition 8.3 Docker project. Create your own copy of it.
+
+### Create the repository on GitHub
+
+1. Go to [github.com/ia-eknorr/project-template](https://github.com/ia-eknorr/project-template)
+2. Click the green **Use this template** button, then select **Create a new repository**
+3. Fill in the form:
+   - **Owner**: your personal GitHub account
+   - **Repository name**: your project name, e.g. `my-ignition-project` (lowercase with dashes)
+   - **Visibility**: Private is a good default for a learning repo
+   - Click **Create repository**
+
+### Clone the repository to your machine
+
+```shell
+cd ~/projects
+git clone https://github.com/<your-username>/my-ignition-project.git
+cd my-ignition-project
+```
+
+### Configure the environment
+
+The template uses a `.env` file for per-machine settings that should not be committed.
+
+```shell
+# Mac / Linux
+cp .env.example .env
+
+# Windows (PowerShell)
+copy .env.example .env
+```
+
+Open `.env` in your editor and set:
+
+- `GATEWAY_NAME` to match your repository name (e.g., `my-ignition-project`). This becomes the Traefik hostname - your gateway will be available at `https://my-ignition-project.localtest.me`.
+- `GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD` to the credentials you want for the gateway's admin user.
+
+:::note .env stays out of git
+`.env` is listed in `.gitignore` by default. Environment-specific values (gateway name, credentials) should never be committed. Share configuration through `.env.example` instead.
+:::
 
 ---
 

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -111,7 +111,7 @@ Scan the output for these milestones:
   "$ docker compose logs -f gateway",
   "my-ignition-project  | wrapper  | 2026/05/15 21:25:17 | --> Wrapper Started as Console",
   "my-ignition-project  | wrapper  | 2026/05/15 21:25:18 | Launching a JVM...",
-  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:19 | I [IgnitionGateway               ] [21:25:19.001]: Starting Ignition 8.3.6 (b2026042713)",
+  "my-ignition-project  | jvm 1    | 2026/05/15 21:25:19 | I [IgnitionGateway               ] [21:25:19.001]: Starting Ignition __IGNITION_VERSION__ (b2026042713)",
   "my-ignition-project  | jvm 1    | 2026/05/15 21:25:19 | I [g.ModuleManager               ] [21:25:19.304]: Loading modules....",
   "my-ignition-project  | jvm 1    | 2026/05/15 21:25:27 | I [ModuleInstance                ] [21:25:27.282]: Starting up module 'com.inductiveautomation.perspective' v3.3.6 (b2026042713)... module-name=Perspective",
   "my-ignition-project  | jvm 1    | 2026/05/15 21:25:27 | I [IgnitionGateway               ] [21:25:27.450]: Gateway started in 8 seconds."
@@ -129,13 +129,13 @@ Once the logs settle, confirm all three services are accounted for. Pass `-a` so
   "$ docker compose ps -a",
   "NAME                          IMAGE                                COMMAND                  SERVICE     CREATED          STATUS                      PORTS",
   "db-my-ignition-project        postgres:18.4                        \"docker-entrypoint.s…\"   db          2 minutes ago    Up 2 minutes (healthy)      5432/tcp",
-  "my-ignition-project           inductiveautomation/ignition:8.3.6   \"docker-entrypoint.s…\"   gateway     2 minutes ago    Up 2 minutes (healthy)      8088/tcp",
-  "my-ignition-project-bootstrap-1   inductiveautomation/ignition:8.3.6   \"/bin/bash /docker-b…\"   bootstrap   2 minutes ago    Exited (0) 2 minutes ago"
+  "my-ignition-project           inductiveautomation/ignition:__IGNITION_VERSION__   \"docker-entrypoint.s…\"   gateway     2 minutes ago    Up 2 minutes (healthy)      8088/tcp",
+  "my-ignition-project-bootstrap-1   inductiveautomation/ignition:__IGNITION_VERSION__   \"/bin/bash /docker-b…\"   bootstrap   2 minutes ago    Exited (0) 2 minutes ago"
 ]} />
 
 **`bootstrap` showing `Exited (0)` is correct and expected.** It is a one-shot service that exits after completing its work, so it does not appear in `docker compose ps` without the `-a` flag.
 
-Notice that bootstrap uses the same `inductiveautomation/ignition:8.3.6` image as the gateway. It is not a separate prebuilt image - it is the standard Ignition image with a different entrypoint (`/docker-bootstrap.sh`) that runs the seed script and exits.
+Notice that bootstrap uses the same `inductiveautomation/ignition:__IGNITION_VERSION__` image as the gateway. It is not a separate prebuilt image - it is the standard Ignition image with a different entrypoint (`/docker-bootstrap.sh`) that runs the seed script and exits.
 
 ---
 

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -15,7 +15,7 @@ Prerequisites:
 - [Version Control Lab](./version-control-lab.md) completed - you should have a project-template fork cloned locally and understand the git workflow
 - [Workstation Setup](../getting-started/workstation-setup.md) complete (Docker Desktop running)
 - [Traefik Reverse Proxy](../getting-started/traefik.md) set up and running
-- `.env` file created from `.env.example` in your project-template repository
+- `.env` file created from `.env.example` in your project-template repository, with `GATEWAY_ADMIN_PASSWORD` (and optionally `GATEWAY_ADMIN_USERNAME`) set before bringing up the stack
 
 If you do not have a project-template repository yet, complete the [Version Control Lab](./version-control-lab.md) first.
 
@@ -104,7 +104,7 @@ Replace `<GATEWAY_NAME>` with the value you set in your `.env` file (for example
 Traefik generates a self-signed certificate for `*.localtest.me`. Your browser will show a security warning. This is expected for local development - click **Advanced** and then **Proceed** (the exact wording varies by browser). You will not see this warning in a production deployment that uses a real certificate.
 :::
 
-Log in with your admin credentials. On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
+Log in with the username and password you set in `.env` (`GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD`). On the gateway Status page, confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
 
 {/* TODO: screenshot - gateway status page showing gateway name */}
 

--- a/docs/labs/version-control-lab.md
+++ b/docs/labs/version-control-lab.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 10
+sidebar_position: 1
 ---
 
-# Hands-On Lab
+# Version Control Lab
 
 ## Purpose
 

--- a/docs/labs/version-control-lab.md
+++ b/docs/labs/version-control-lab.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Version Control Lab

--- a/docs/reference/docker-command-reference.md
+++ b/docs/reference/docker-command-reference.md
@@ -24,7 +24,6 @@ A quick-reference page for Docker Compose commands used with Ignition projects. 
 | Command | What it does |
 | --- | --- |
 | `docker compose logs -f gateway` | Stream gateway logs live (Ctrl+C to stop) |
-| `docker compose logs -f config-cleanup` | Stream config-cleanup logs live |
 | `docker compose logs gateway` | Print all gateway logs to stdout |
 | `docker compose logs gateway \| grep -i error` | Filter gateway logs for errors |
 | `docker compose logs --tail=100 gateway` | Print last 100 lines of gateway logs |
@@ -48,7 +47,6 @@ A quick-reference page for Docker Compose commands used with Ignition projects. 
 | Symptom | Command to run |
 | --- | --- |
 | Gateway not starting | `docker compose logs gateway` |
-| config-cleanup not reverting files | `docker compose logs config-cleanup` |
 | Port conflict on startup | `docker compose ps` to see what is running and which ports are bound |
 | Traefik route not working | `docker compose ps` - verify the `proxy` network is up and `gateway` is healthy |
 | Gateway stuck in trial mode after reset | Volume was deleted with `-v`; reactivate the license from **Config > Licensing** |

--- a/docs/reference/docker-command-reference.md
+++ b/docs/reference/docker-command-reference.md
@@ -39,7 +39,7 @@ A quick-reference page for Docker Compose commands used with Ignition projects. 
 | `docker compose pull` | Pull the latest version of all images (does not restart services) |
 | `docker compose pull gateway` | Pull only the Ignition gateway image |
 | `docker images \| grep ignition` | List locally cached Ignition images and their tags |
-| `docker rmi inductiveautomation/ignition:8.3.6` | Remove a specific image version from local cache |
+| `docker rmi inductiveautomation/ignition:__IGNITION_VERSION__` | Remove a specific image version from local cache |
 | `docker compose build` | Build any services with a local `build:` context (not applicable to the stock template) |
 
 ## Troubleshooting Quick-Reference

--- a/docs/reference/docker-command-reference.md
+++ b/docs/reference/docker-command-reference.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+---
+
+# Docker Command Reference
+
+A quick-reference page for Docker Compose commands used with Ignition projects. All commands run from the project directory - the folder that contains your `docker-compose.yml` file.
+
+## Gateway Lifecycle
+
+| Command | What it does |
+| --- | --- |
+| `docker compose up -d` | Start all services in the background |
+| `docker compose down` | Stop and remove containers; volume and data preserved |
+| `docker compose down -v` | Stop containers and delete all volumes (full reset - destroys gateway data) |
+| `docker compose restart gateway` | Restart the gateway service only; volume preserved |
+| `docker compose restart` | Restart all services |
+| `docker compose stop` | Stop containers without removing them |
+| `docker compose start` | Start previously stopped containers |
+| `docker compose down && docker compose up -d` | Full stack restart; volume preserved |
+
+## Logs and Inspection
+
+| Command | What it does |
+| --- | --- |
+| `docker compose logs -f gateway` | Stream gateway logs live (Ctrl+C to stop) |
+| `docker compose logs -f config-cleanup` | Stream config-cleanup logs live |
+| `docker compose logs gateway` | Print all gateway logs to stdout |
+| `docker compose logs gateway \| grep -i error` | Filter gateway logs for errors |
+| `docker compose logs --tail=100 gateway` | Print last 100 lines of gateway logs |
+| `docker compose ps` | Show all services, their status, and exposed ports |
+| `docker compose exec gateway bash` | Open a shell inside the running gateway container |
+| `docker compose exec db psql -U ignition ignition` | Open a psql session in the Ignition database |
+| `docker inspect ignition-data` | Inspect the `ignition-data` volume (path, driver, labels) |
+
+## Image Management
+
+| Command | What it does |
+| --- | --- |
+| `docker compose pull` | Pull the latest version of all images (does not restart services) |
+| `docker compose pull gateway` | Pull only the Ignition gateway image |
+| `docker images \| grep ignition` | List locally cached Ignition images and their tags |
+| `docker rmi inductiveautomation/ignition:8.3.6` | Remove a specific image version from local cache |
+| `docker compose build` | Build any services with a local `build:` context (not applicable to the stock template) |
+
+## Troubleshooting Quick-Reference
+
+| Symptom | Command to run |
+| --- | --- |
+| Gateway not starting | `docker compose logs gateway` |
+| config-cleanup not reverting files | `docker compose logs config-cleanup` |
+| Port conflict on startup | `docker compose ps` to see what is running and which ports are bound |
+| Traefik route not working | `docker compose ps` - verify the `proxy` network is up and `gateway` is healthy |
+| Gateway stuck in trial mode after reset | Volume was deleted with `-v`; reactivate the license from **Config > Licensing** |
+| Database connection errors in gateway logs | `docker compose logs db` - check if PostgreSQL passed its healthcheck |
+| Bootstrap runs on every start | Sentinel file missing from volume; check bootstrap service logs |
+| Designer cannot connect | Confirm gateway is fully started - look for `Gateway successfully started` in logs |

--- a/docs/reference/git-style-guide.md
+++ b/docs/reference/git-style-guide.md
@@ -162,4 +162,4 @@ For host installs or full data directory mounts, additional patterns may be need
 [Ignition 8.3 Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide)
 for the full reference.
 
-See the [Hands-On Lab](../labs/git-ignition-lab.md) for a walkthrough of this structure in practice.
+See the [Version Control Lab](../labs/version-control-lab.md) for a walkthrough of this structure in practice.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -101,7 +101,7 @@ const config: Config = {
           items: [
             { label: "Getting Started", to: "/docs/getting-started" },
             { label: "Version Control", to: "/docs/guides/version-control/intro" },
-            { label: "Git Lab", to: "/docs/labs/git-ignition-lab" },
+            { label: "Version Control Lab", to: "/docs/labs/version-control-lab" },
             { label: "Style Guide", to: "/docs/reference/git-style-guide" },
             { label: "Tools", to: "/docs/tools/overview" },
           ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,8 @@
 import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
+import remarkTokenSubstitution from "./src/plugins/remark-token-substitution";
+import { IGNITION_VERSION } from "./src/constants";
 
 const config: Config = {
   title: "Ignition Guides",
@@ -62,6 +64,9 @@ const config: Config = {
           sidebarPath: "./sidebars.ts",
           editUrl:
             "https://github.com/ia-eknorr/ignition-guides/tree/main/",
+          beforeDefaultRemarkPlugins: [
+            [remarkTokenSubstitution, { tokens: { IGNITION_VERSION } }],
+          ],
         },
         blog: false,
         theme: {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^src/constants\\.ts$"],
+      "matchStrings": [
+        "IGNITION_VERSION\\s*=\\s*['\"](?<currentValue>[^'\"]+)['\"]"
+      ],
+      "depNameTemplate": "inductiveautomation/ignition",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["inductiveautomation/ignition"],
+      "commitMessageTopic": "Ignition image",
+      "commitMessageExtra": "to {{newVersion}}",
+      "labels": ["dependencies", "ignition-version"]
+    }
+  ]
+}

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -28,17 +28,35 @@ const sidebars: SidebarsConfig = {
             "guides/version-control/merge-a-pull-request",
           ],
         },
+        {
+          type: "category",
+          label: "Docker",
+          link: { type: "doc", id: "guides/docker/intro" },
+          items: [
+            "guides/docker/compose-architecture",
+            "guides/docker/volume-strategy",
+            "guides/docker/licensing",
+            "guides/docker/day-two-operations",
+          ],
+        },
       ],
     },
     {
       type: "category",
       label: "Labs",
-      items: ["labs/git-ignition-lab"],
+      items: [
+        "labs/version-control-lab",
+        "labs/docker-ignition-lab",
+      ],
     },
     {
       type: "category",
       label: "Reference",
-      items: ["reference/git-style-guide", "reference/resource-collections"],
+      items: [
+        "reference/git-style-guide",
+        "reference/resource-collections",
+        "reference/docker-command-reference",
+      ],
     },
     {
       type: "category",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -19,17 +19,6 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: "category",
-          label: "Version Control",
-          link: { type: "doc", id: "guides/version-control/intro" },
-          items: [
-            "guides/version-control/initialize-repository",
-            "guides/version-control/branching-strategy",
-            "guides/version-control/create-a-branch",
-            "guides/version-control/merge-a-pull-request",
-          ],
-        },
-        {
-          type: "category",
           label: "Docker",
           link: { type: "doc", id: "guides/docker/intro" },
           items: [
@@ -39,14 +28,25 @@ const sidebars: SidebarsConfig = {
             "guides/docker/day-two-operations",
           ],
         },
+        {
+          type: "category",
+          label: "Version Control",
+          link: { type: "doc", id: "guides/version-control/intro" },
+          items: [
+            "guides/version-control/initialize-repository",
+            "guides/version-control/branching-strategy",
+            "guides/version-control/create-a-branch",
+            "guides/version-control/merge-a-pull-request",
+          ],
+        },
       ],
     },
     {
       type: "category",
       label: "Labs",
       items: [
-        "labs/version-control-lab",
         "labs/docker-ignition-lab",
+        "labs/version-control-lab",
       ],
     },
     {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const IGNITION_VERSION = '8.3.6';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,10 +43,10 @@ const features: Feature[] = [
     cta: "Read the guide",
   },
   {
-    title: "Hands-On Lab",
+    title: "Version Control Lab",
     Icon: TerminalIcon,
     description: "Set up a Docker-based Ignition project with version control end to end, from fork to merged pull request.",
-    to: "/docs/labs/git-ignition-lab",
+    to: "/docs/labs/version-control-lab",
     cta: "Start the lab",
   },
   {

--- a/src/plugins/remark-token-substitution.ts
+++ b/src/plugins/remark-token-substitution.ts
@@ -1,0 +1,29 @@
+import { visit } from "unist-util-visit";
+import type { Plugin } from "unified";
+import type { Root } from "mdast";
+
+type Options = { tokens: Record<string, string> };
+
+const plugin: Plugin<[Options], Root> = (options) => {
+  const { tokens } = options;
+  const replace = (s: string) =>
+    Object.entries(tokens).reduce(
+      (acc, [k, v]) => acc.replace(new RegExp(`__${k}__`, "g"), v),
+      s,
+    );
+  return (tree) => {
+    visit(tree, (node: any) => {
+      if (
+        node.type === "text" ||
+        node.type === "code" ||
+        node.type === "inlineCode"
+      ) {
+        if (typeof node.value === "string") {
+          node.value = replace(node.value);
+        }
+      }
+    });
+  };
+};
+
+export default plugin;

--- a/src/plugins/remark-token-substitution.ts
+++ b/src/plugins/remark-token-substitution.ts
@@ -11,7 +11,51 @@ const plugin: Plugin<[Options], Root> = (options) => {
       (acc, [k, v]) => acc.replace(new RegExp(`__${k}__`, "g"), v),
       s,
     );
+  const walkEstree = (node: any) => {
+    if (!node || typeof node !== "object") return;
+    if (node.type === "Literal" && typeof node.value === "string") {
+      node.value = replace(node.value);
+      if (typeof node.raw === "string") {
+        node.raw = replace(node.raw);
+      }
+    }
+    if (node.type === "TemplateElement" && node.value) {
+      if (typeof node.value.raw === "string") {
+        node.value.raw = replace(node.value.raw);
+      }
+      if (typeof node.value.cooked === "string") {
+        node.value.cooked = replace(node.value.cooked);
+      }
+    }
+    for (const key of Object.keys(node)) {
+      const child = node[key];
+      if (Array.isArray(child)) {
+        child.forEach(walkEstree);
+      } else if (child && typeof child === "object" && child.type) {
+        walkEstree(child);
+      }
+    }
+  };
   return (tree) => {
+    // Markdown parses __TOKEN__ as bold (strong wrapping text "TOKEN").
+    // Detect that shape and rewrite the strong node into a plain text node.
+    visit(tree, (node: any, index, parent: any) => {
+      if (
+        node.type === "strong" &&
+        Array.isArray(node.children) &&
+        node.children.length === 1 &&
+        node.children[0].type === "text" &&
+        typeof node.children[0].value === "string" &&
+        Object.prototype.hasOwnProperty.call(tokens, node.children[0].value) &&
+        parent &&
+        typeof index === "number"
+      ) {
+        parent.children[index] = {
+          type: "text",
+          value: tokens[node.children[0].value],
+        };
+      }
+    });
     visit(tree, (node: any) => {
       if (
         node.type === "text" ||
@@ -21,6 +65,26 @@ const plugin: Plugin<[Options], Root> = (options) => {
         if (typeof node.value === "string") {
           node.value = replace(node.value);
         }
+      }
+      // MDX JSX attribute values (e.g. <Terminal lines={[...]} />)
+      if (
+        node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement"
+      ) {
+        if (Array.isArray(node.attributes)) {
+          for (const attr of node.attributes) {
+            const estree = attr?.value?.data?.estree;
+            if (estree) walkEstree(estree);
+          }
+        }
+      }
+      // MDX expressions inside markdown (e.g. {someString})
+      if (
+        node.type === "mdxFlowExpression" ||
+        node.type === "mdxTextExpression"
+      ) {
+        const estree = node?.data?.estree;
+        if (estree) walkEstree(estree);
       }
     });
   };


### PR DESCRIPTION
## Summary

Introduces a single source of truth for the Ignition version (`src/constants.ts`) and a small remark plugin that substitutes `__IGNITION_VERSION__` tokens in docs at build time. Adds a Renovate config so new Ignition images on Docker Hub automatically open PRs bumping the constant.

- `src/constants.ts` exports `IGNITION_VERSION` (currently `8.3.6`).
- `src/plugins/remark-token-substitution.ts` walks the MDAST and replaces `__TOKEN__` placeholders in text, inline code, fenced code, and MDX JSX attribute expressions (so `<Terminal lines={[...]} />` works).
- Wired into the docs preset via `beforeDefaultRemarkPlugins` so syntax highlighting still runs on substituted code.
- Replaced 8 hardcoded `8.3.6` occurrences across 4 docs files with `__IGNITION_VERSION__`.
- `renovate.json` watches `src/constants.ts` against the `inductiveautomation/ignition` Docker Hub repo and opens labelled PRs on new releases.

## Why

Releases shouldn't require a find-and-replace across the docs. One constant, one Renovate PR, and the entire site reflects the new version.

## Merge order

This should land after #38 (Phase 1 Docker tier), which it branches from.

## Test plan

- [x] `npm run build` succeeds (only pre-existing broken-link warnings, unrelated)
- [x] Rendered HTML in `build/` shows the substituted version (e.g. `inductiveautomation/ignition:8.3.6`) and no raw `__IGNITION_VERSION__` tokens
- [x] `<Terminal>` JSX lines render with the substituted version
- [ ] Renovate self-test on the repo picks up `src/constants.ts`