### PR TITLE
footer + tagline: align with site IA

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -6,7 +6,7 @@ import { IGNITION_VERSION } from "./src/constants";
 
 const config: Config = {
   title: "Ignition Guides",
-  tagline: "Unofficial guides for Ignition SCADA infrastructure and workflows",
+  tagline: "Community guides for Ignition SCADA using modern development practices",
   favicon: "img/favicon.ico",
 
   url: "https://ia-eknorr.github.io",
@@ -46,7 +46,7 @@ const config: Config = {
       "@signalwire/docusaurus-plugin-llms-txt",
       {
         siteTitle: "Ignition Guides",
-        siteDescription: "Unofficial guides for Ignition SCADA infrastructure and workflows",
+        siteDescription: "Community guides for Ignition SCADA using modern development practices",
         depth: 2,
         content: {
           enableLlmsFullTxt: true,
@@ -106,12 +106,12 @@ const config: Config = {
       style: "dark",
       links: [
         {
-          title: "Guides",
+          title: "Documentation",
           items: [
             { label: "Getting Started", to: "/docs/getting-started" },
-            { label: "Version Control", to: "/docs/guides/version-control/intro" },
-            { label: "Version Control Lab", to: "/docs/labs/version-control-lab" },
-            { label: "Style Guide", to: "/docs/reference/git-style-guide" },
+            { label: "Guides", to: "/docs/guides/docker/intro" },
+            { label: "Labs", to: "/docs/labs/docker-ignition-lab" },
+            { label: "Reference", to: "/docs/reference/git-style-guide" },
             { label: "Tools", to: "/docs/tools/overview" },
           ],
         },


### PR DESCRIPTION
## Summary

Two small fixes to `docusaurus.config.ts`:

### Footer
The left footer column was labeled **Guides** but mixed a getting-started page, a guide, a lab, a reference page, and tools. Renamed to **Documentation** and updated the items to mirror the site's top-level sections (which the "What Is in Here" table already uses):

- Getting Started
- Guides (links to first guide)
- Labs (links to first lab)
- Reference (links to Style Guide for now)
- Tools

### Tagline
Old: *"Unofficial guides for Ignition SCADA infrastructure and workflows"* — the phrase "SCADA infrastructure" doesn't really parse, since Ignition itself is SCADA software and the guides are about applying modern dev/ops practices to it.

New: *"Community guides for Ignition SCADA using modern development practices"* — matches the Getting Started page intro almost verbatim, so the brand voice is consistent across the site.

## Test plan

- [x] `npm run build` passes
- [x] Footer column is labeled Documentation, items match site IA
- [x] Tagline updated in both `tagline` and `siteDescription` (used by social cards / OG metadata)