### PR TITLE
colorMode: binary light/dark toggle that defaults to system

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -21,6 +21,18 @@ const config: Config = {
 
   onBrokenLinks: "throw",
 
+  headTags: [
+    {
+      // Sets data-theme before React hydrates: respects the user's stored choice
+      // (theme-cdb) if any, otherwise falls back to the system color-scheme preference.
+      // Combined with colorMode.respectPrefersColorScheme = false, this gives a binary
+      // light/dark toggle that defaults to system on first visit.
+      tagName: "script",
+      attributes: {},
+      innerHTML: `(function(){try{var s=localStorage.getItem('theme-cdb');var t=(s==='light'||s==='dark')?s:(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`,
+    },
+  ],
+
   markdown: {
     mermaid: true,
     hooks: {
@@ -138,7 +150,7 @@ const config: Config = {
     },
     colorMode: {
       defaultMode: "light",
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     zoom: {
       selector: ".markdown img",


### PR DESCRIPTION
## Summary

Switch the navbar color-mode toggle to a binary light/dark cycle while keeping system preference as the first-visit default.

## Behavior

| Scenario | Result |
|---|---|
| First visit, OS in dark mode | Site loads dark |
| First visit, OS in light mode | Site loads light |
| User clicks toggle | Cycles light ↔ dark (no system option) |
| Reload after user picked dark | Site loads dark, no flash |
| OS pref changes after user already toggled | User's choice wins (until they clear storage) |

## How

Two changes to `docusaurus.config.ts`:

1. `colorMode.respectPrefersColorScheme` set to `false`. Docusaurus's built-in three-way toggle (light → dark → system) becomes a binary toggle (light ↔ dark).
2. A tiny inline `<script>` in `headTags` runs in `<head>` before React hydrates. It checks Docusaurus's storage key (`theme-cdb`), and:
   - If the user has a stored choice, applies it to `data-theme` immediately (prevents FOUC on reload).
   - Otherwise reads `prefers-color-scheme` and applies the OS preference.

Docusaurus's ColorModeProvider reads `data-theme` from `documentElement` when it initializes, so the script's value is honored.

## Test plan

- [x] First visit (cleared localStorage) on light system → loads light
- [x] First visit on dark system → loads dark
- [x] Click toggle: binary cycle confirmed (light → dark → light)
- [x] Reload after picking dark → immediately dark, no flash