### PR TITLE
learning pathways: use Link components for navigation

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import Link from "@docusaurus/Link";
+
 # Getting Started
 
 Welcome to Ignition Guides - a collection of community guides for working with
@@ -24,9 +26,9 @@ Concept guides and hands-on labs are organized separately because they have diff
   <div className="learn-tier__label">Set up once</div>
   <div className="learn-setup">
     <ul>
-      <li><a href="./workstation-setup">Workstation Setup</a> - required for every guide</li>
-      <li><a href="./traefik">Traefik Reverse Proxy</a> - required for any lab</li>
-      <li><a href="./kubernetes-setup">Kubernetes Setup</a> - required for the Helm lab only</li>
+      <li><Link to="/docs/getting-started/workstation-setup">Workstation Setup</Link> - required for every guide</li>
+      <li><Link to="/docs/getting-started/traefik">Traefik Reverse Proxy</Link> - required for any lab</li>
+      <li><Link to="/docs/getting-started/kubernetes-setup">Kubernetes Setup</Link> - required for the Helm lab only</li>
     </ul>
   </div>
 </div>
@@ -35,18 +37,18 @@ Concept guides and hands-on labs are organized separately because they have diff
   <div className="learn-tier__label">Concept guides</div>
   <p className="learn-tier__desc">Read in any order. Each guide stands on its own and explains how a piece of the system works.</p>
   <div className="learn-grid">
-    <a className="learn-card" href="../guides/docker/intro">
+    <Link className="learn-card" to="/docs/guides/docker/intro">
       <h3 className="learn-card__title">Containerization</h3>
       <p className="learn-card__desc">Docker Compose, the project-template architecture, licensing, and day-to-day gateway operations.</p>
-    </a>
-    <a className="learn-card" href="../guides/version-control/intro">
+    </Link>
+    <Link className="learn-card" to="/docs/guides/version-control/intro">
       <h3 className="learn-card__title">Version Control</h3>
       <p className="learn-card__desc">Git, GitHub, and source-control workflows for the Ignition project files your gateway produces.</p>
-    </a>
-    <a className="learn-card" href="../guides/kubernetes/concepts">
+    </Link>
+    <Link className="learn-card" to="/docs/guides/kubernetes/concepts">
       <h3 className="learn-card__title">Orchestration</h3>
       <p className="learn-card__desc">Kubernetes concepts for Ignition and the official Inductive Automation Helm chart.</p>
-    </a>
+    </Link>
   </div>
 </div>
 
@@ -54,20 +56,20 @@ Concept guides and hands-on labs are organized separately because they have diff
   <div className="learn-tier__label">Hands-on labs</div>
   <p className="learn-tier__desc">Recommended order. Labs build on a local Ignition gateway, so later labs reuse the setup from earlier ones.</p>
   <div className="learn-grid">
-    <a className="learn-card learn-card--lab" href="../labs/docker-ignition-lab">
+    <Link className="learn-card learn-card--lab" to="/docs/labs/docker-ignition-lab">
       <div className="learn-card__number">1</div>
       <h3 className="learn-card__title">Docker Ignition</h3>
       <p className="learn-card__desc">Stand up an Ignition gateway from the project template using Docker Compose.</p>
-    </a>
-    <a className="learn-card learn-card--lab" href="../labs/version-control-lab">
+    </Link>
+    <Link className="learn-card learn-card--lab" to="/docs/labs/version-control-lab">
       <div className="learn-card__number">2</div>
       <h3 className="learn-card__title">Version Control</h3>
       <p className="learn-card__desc">Put your gateway's project files under Git: branch, commit, and merge a change.</p>
-    </a>
-    <a className="learn-card learn-card--lab" href="../labs/helm-ignition-lab">
+    </Link>
+    <Link className="learn-card learn-card--lab" to="/docs/labs/helm-ignition-lab">
       <div className="learn-card__number">3</div>
       <h3 className="learn-card__title">Helm Ignition</h3>
       <p className="learn-card__desc">Deploy an Ignition gateway on a local Kubernetes cluster with the official Helm chart.</p>
-    </a>
+    </Link>
   </div>
 </div>


### PR DESCRIPTION
### Background

The learning-pathway cards on the Getting Started page (added in #44) link with raw relative `<a href="./...">` / `<a href="../...">` anchors. Two problems follow from that:

- Docusaurus's `onBrokenLinks: "throw"` checker only validates markdown links and `<Link>` components, so these anchors are invisible to it. A green build does not prove they resolve.
- Raw relative anchors resolve correctly only when the page is viewed with a trailing slash (`/docs/getting-started/`). The home page "Get Started" button links without one, and `docusaurus serve` does not redirect to add it, so resolution becomes host-dependent.

### Changes

- Convert all nine learning-pathway anchors (3 setup links, 3 concept-guide cards, 3 lab cards) from raw `<a href>` to `<Link to="/docs/...">`, with the `@docusaurus/Link` import added to the page.
- Rendered output now emits absolute, baseUrl-prefixed hrefs (`/ignition-guides/docs/...`) that no longer depend on trailing-slash resolution, and the links are now covered by the build's broken-link checker.

### Reviewer Notes

Verified with a clean `npm run build` (passes with `onBrokenLinks: "throw"`) and by inspecting the generated HTML for all nine targets. No content or styling changes — `className` values are preserved, so the card layout is unchanged.