### PR TITLE
feat: add observability pillar (gateway telemetry, metrics, logs)

### DIFF
--- a/docs/guides/observability/gateway-telemetry.md
+++ b/docs/guides/observability/gateway-telemetry.md
@@ -11,7 +11,7 @@ This guide shows how to wire the agent for Docker Compose and bare-metal deploym
 
 ## How it works
 
-```
+```text
 Ignition gateway (JVM)
   └── OTel Java agent (attached at startup)
         ├── metrics  → OTLP → Alloy/Collector → Mimir / Prometheus

--- a/docs/guides/observability/gateway-telemetry.md
+++ b/docs/guides/observability/gateway-telemetry.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 2
+applies_to: [docker, kubernetes, bare-metal]
+---
+
+# Gateway Telemetry
+
+An Ignition gateway does not expose a built-in metrics or telemetry endpoint. Observability requires attaching the **OpenTelemetry Java agent** to the gateway process. The agent instruments the JVM at startup, intercepts Ignition's internal Dropwizard/Codahale metrics, and pushes metrics, traces, and logs to a collector over OTLP. Nothing is scraped from the gateway; everything is pushed.
+
+This guide shows how to wire the agent for Docker Compose and bare-metal deployments. The key concepts and property names are the same in both cases. For Kubernetes, the OTel operator can inject the agent automatically via an `Instrumentation` CRD, covered briefly at the end of this page.
+
+## How it works
+
+```
+Ignition gateway (JVM)
+  └── OTel Java agent (attached at startup)
+        ├── metrics  → OTLP → Alloy/Collector → Mimir / Prometheus
+        ├── traces   → OTLP → Alloy/Collector → Tempo
+        └── logs     → OTLP → Alloy/Collector → Loki
+```
+
+The agent is loaded by the JVM before any application code runs. It instruments:
+
+- **Dropwizard/Codahale metrics** (`otel.instrumentation.dropwizard-metrics.enabled=true`): these are Ignition's internal performance counters (tag provider throughput, Perspective session counts, gateway thread pool stats, and more). Without this setting the most useful Ignition-specific metrics are invisible.
+- **JDBC datasource metrics** (`otel.instrumentation.jdbc-datasource.enabled=true`): per-connection-pool query counts, latency, and pool utilization for every database connection configured in the gateway.
+- **Logback appender**: every log entry written through Ignition's SLF4J/Logback logging layer is forwarded as an OTLP log record.
+- **HTTP spans**: traces for every inbound HTTP request, giving you latency and error-rate breakdowns for the gateway web interface and Perspective sessions.
+
+## Prerequisites
+
+Download the OpenTelemetry Java agent JAR from the [OpenTelemetry releases page](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases). The JAR filename is `opentelemetry-javaagent.jar`. Place it somewhere the gateway process can read.
+
+A collector must be reachable over the network at OTLP HTTP (`:4318`) or gRPC (`:4317`). The [Metrics and Log Stack guide](./metrics-stack.md) covers standing up Grafana Alloy as the collector.
+
+## Docker Compose wiring
+
+The agent JAR is mounted into the container from the host and passed to the JVM through the `command:` block after the `--` delimiter. Environment variables prefixed `OTEL_` set agent properties at the container level; the `-Dotel.*` JVM system properties in the `command:` block override them or provide values that reference compose variables.
+
+```yaml
+services:
+  ignition:
+    image: inductiveautomation/ignition:8.3.6
+    volumes:
+      # Mount the agent JAR and (optionally) the properties file
+      - ./dependencies:/usr/local/bin/ignition/dependencies
+    environment:
+      ACCEPT_IGNITION_EULA: "Y"
+      OTEL_SERVICE_NAME: ${GATEWAY_NAME}
+    command: >
+      -n ${GATEWAY_NAME}
+      -m 1024
+      -h 8088
+      -s 8043
+      -a ${GATEWAY_NAME}
+      --
+      -javaagent:/usr/local/bin/ignition/dependencies/opentelemetry-javaagent.jar
+      -Dotel.service.name=${GATEWAY_NAME}
+      -Dotel.resource.attributes=gateway=${GATEWAY_NAME},service.name=${GATEWAY_NAME},environment=${MODE},ignition.version=${VERSION}
+      -Dotel.exporter.otlp.protocol=http/protobuf
+      -Dotel.javaagent.logging=none
+      -Dotel.instrumentation.dropwizard-metrics.enabled=true
+      -Dotel.instrumentation.jdbc-datasource.enabled=true
+      -Dotel.instrumentation.runtime-telemetry-java17.enabled=false
+      -Dotel.instrumentation.runtime-telemetry.enabled=false
+      -Dotel.logs.exporter=otlp
+      -Dotel.exporter.otlp.logs.endpoint=http://${ALLOY}:4318/v1/logs
+      -Dotel.instrumentation.logback-appender.enabled=true
+      -Dotel.instrumentation.logback-mdc.enabled=true
+      -Dotel.instrumentation.logback-appender.experimental.capture-mdc-attributes=*
+      -Dotel.traces.exporter=otlp
+      -Dotel.exporter.otlp.traces.protocol=http/protobuf
+      -Dotel.exporter.otlp.traces.endpoint=http://${ALLOY}:4318/v1/traces
+      -Dotel.metrics.exporter=otlp
+      -Dotel.exporter.otlp.metrics.protocol=http/protobuf
+      -Dotel.exporter.otlp.metrics.endpoint=http://${ALLOY}:4318/v1/metrics
+```
+
+A few points about the arguments above:
+
+- `--` is the delimiter Ignition uses to separate its own startup arguments from JVM system properties. See [Supplemental JVM and Wrapper Arguments](https://docs.inductiveautomation.com/docs/8.3/platform/docker-image#supplemental-jvm-and-wrapper-arguments) for the full description of this convention.
+- `runtime-telemetry` and `runtime-telemetry-java17` are disabled because the Dropwizard instrumentation already captures the JVM metrics Ignition exposes; enabling both produces duplicated metric series.
+- `otel.javaagent.logging=none` silences the agent's own startup chatter in the container log stream. Change to `simple` when debugging agent configuration.
+- The `ALLOY` variable should resolve to the DNS name of the Alloy container on the shared Docker network. In the observability stack compose file this is `alloy`.
+
+For a complete list of properties and what each controls, see the [OTel Properties Reference](../../reference/ignition-otel-properties.md).
+
+## Bare-metal wiring
+
+On a bare-metal (or VM) install the gateway runs as a system service managed by the Tanuki Java Service Wrapper. All JVM arguments are set in `ignition.conf`, located in the Ignition install directory (typically `C:\Program Files\Inductive Automation\Ignition\` on Windows or `/usr/local/bin/ignition/` on Linux).
+
+The cleanest approach for bare-metal is to put OTel properties in a separate `otel-agent.properties` file and point `ignition.conf` at it with one JVM arg.
+
+### `ignition.conf` additions
+
+Add these lines after the existing `wrapper.java.additional.*` entries. Use index numbers that do not collide with existing entries (indexes 20 and 25 are free in a standard install):
+
+```properties
+#Agent Settings
+wrapper.java.additional.20=-javaagent:"/path/to/opentelemetry-javaagent.jar"
+wrapper.java.additional.25=-Dotel.javaagent.configuration-file="/path/to/otel-agent.properties"
+```
+
+Replace `/path/to/` with the actual path where you placed the JAR and properties file. The JAR must be readable by the account that runs the Ignition service.
+
+For the full `ignition.conf` structure and existing `wrapper.java.additional.*` slots, see the [Gateway Configuration File Reference](https://docs.inductiveautomation.com/docs/8.3/appendix/reference-pages/gateway-configuration-file-reference).
+
+### `otel-agent.properties`
+
+```properties
+# OpenTelemetry Java Agent Configuration
+# NOTE: -javaagent: entries must remain as JVM args in ignition.conf
+
+# --- Identity ---
+otel.service.name=my-gateway
+otel.resource.attributes=service.name=my-gateway,gateway=my-gateway,environment=Production,ignition.version=8.3.6
+
+# --- Exporter ---
+otel.exporter.otlp.protocol=http/protobuf
+
+# --- Logging ---
+otel.javaagent.logging=none
+# otel.javaagent.logging=simple
+
+# --- Metrics ---
+otel.instrumentation.dropwizard-metrics.enabled=true
+otel.instrumentation.jdbc-datasource.enabled=true
+otel.metrics.exporter=otlp
+otel.exporter.otlp.metrics.protocol=http/protobuf
+otel.exporter.otlp.metrics.endpoint=http://<alloy-host>:4318/v1/metrics
+otel.metric.export.interval=5000
+
+# --- Logs ---
+otel.logs.exporter=otlp
+otel.exporter.otlp.logs.endpoint=http://<alloy-host>:4318/v1/logs
+otel.instrumentation.logback-appender.enabled=true
+otel.instrumentation.logback-mdc.enabled=true
+
+# --- Traces ---
+otel.traces.exporter=otlp
+otel.exporter.otlp.traces.protocol=http/protobuf
+otel.exporter.otlp.traces.endpoint=http://<alloy-host>:4318/v1/traces
+```
+
+Replace `<alloy-host>` with the hostname or IP of your Alloy collector. For a local dev machine with the observability stack running on the same host, this is typically `localhost`. After editing `ignition.conf`, restart the Ignition service for changes to take effect.
+
+## On Kubernetes (in-cluster auto-inject)
+
+The OTel Operator for Kubernetes can inject the agent automatically into gateway pods via an `Instrumentation` CRD, eliminating the need to manage the JAR or configure JVM args by hand. The in-cluster pattern also enables a dual OTLP and Prometheus export path, where the agent exposes a `/metrics` endpoint on port 9000 for scraping by Prometheus or the kube-prometheus-stack.
+
+This pattern is covered as a forward topic. The Instrumentation CRD wiring and the PodMonitor that targets port 9000 are referenced in the [Metrics and Log Stack guide](./metrics-stack.md).
+
+## What you get after wiring
+
+Once the gateway restarts with the agent attached and the collector is reachable, three signal families appear in your stack:
+
+- **Metrics**: JVM heap, GC pause duration and frequency, thread pool utilization, HTTP request rates and latencies, Ignition-specific gauges (tag provider write throughput, Perspective session counts), and JDBC connection pool stats per configured database. All available in Grafana via Mimir.
+- **Traces**: Spans for every inbound HTTP request handled by the gateway web server, including Perspective page loads and Designer connections. Cross-linked to logs and profiles in the Grafana datasource configuration.
+- **Logs**: Every entry written through the gateway's Logback appender forwarded as a structured OTLP log record and available in Loki. MDC fields (trace ID, span ID) are captured, enabling trace-to-log correlation in Grafana.
+
+For the metrics and log collection stack, see [Metrics and Log Stack](./metrics-stack.md). For the full property reference, see [OTel Properties Reference](../../reference/ignition-otel-properties.md).

--- a/docs/guides/observability/intro.md
+++ b/docs/guides/observability/intro.md
@@ -18,9 +18,15 @@ A useful picture of a running gateway combines a few signal families:
 
 ## How the pillar is organized
 
-The flagship guide wires the gateway's OpenTelemetry export, the agnostic foundation every other piece builds on. From there, guides cover the metrics stack (Prometheus/Grafana or Grafana LGTM), logs (Loki + Alloy), traces and profiling (Tempo + Pyroscope), external exporters, and custom Ignition metrics. These land across upcoming rounds.
+The flagship guide wires the gateway's OpenTelemetry export, the agnostic foundation every other piece builds on:
 
-As the pillar grows, short one-screen operational tips will be collected under a **Tasks** sub-section, following the same Concepts / Tasks / Tutorials / Reference convention the rest of the site uses.
+- [Gateway Telemetry](./gateway-telemetry.md): attaches the OTel Java agent to the gateway process and configures it to push metrics, traces, and logs over OTLP. Start here.
+- [Metrics and Log Stack](./metrics-stack.md): the Grafana LGTM collector and storage stack for Docker Compose, and the kube-prometheus-stack alternative for Kubernetes.
+- [Log Pipeline](./logs.md): the Alloy pipeline that processes, filters, and routes gateway log records to Loki, with rationale for each filter rule.
+
+The [OTel Properties Reference](../../reference/ignition-otel-properties.md) lists every agent property used in the guides with a one-line description.
+
+Further guides covering traces and profiling (Tempo, Pyroscope), external exporters, and custom Ignition metrics land in upcoming rounds. Short one-screen operational tips will be collected under a **Tasks** sub-section as the pillar grows, following the same Concepts / Tasks / Tutorials / Reference convention the rest of the site uses.
 
 ## Scope
 

--- a/docs/guides/observability/logs.md
+++ b/docs/guides/observability/logs.md
@@ -1,0 +1,237 @@
+---
+sidebar_position: 4
+applies_to: [docker, kubernetes]
+---
+
+# Log Pipeline
+
+After [Gateway Telemetry](./gateway-telemetry.md) wiring is complete, the OTel agent forwards every Ignition log entry as an OTLP log record to Alloy. From there Alloy processes, filters, and writes the records to Loki. This guide explains the Alloy pipeline config and the rationale behind each filter and processing stage.
+
+The pipeline described here has two variants: one for Docker Compose (reads from the Docker log socket), and one for Kubernetes (reads via the Kubernetes pod log API). Both funnel into the same Loki backend.
+
+## Docker Compose pipeline
+
+In the Docker Compose environment Alloy uses `loki.source.docker` to tail container logs, enriches them with container labels, and processes them through a pipeline before writing to Loki.
+
+```alloy
+discovery.docker "ignition" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "5s"
+}
+
+discovery.relabel "ignition" {
+  targets = []
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+}
+
+loki.source.docker "ignition" {
+  host             = "unix:///var/run/docker.sock"
+  targets          = discovery.docker.ignition.targets
+  forward_to       = [loki.process.add_labels.receiver]
+  relabel_rules    = discovery.relabel.ignition.rules
+  refresh_interval = "5s"
+}
+```
+
+The `discovery.relabel` block strips the leading `/` from Docker container names so the `container` label is just `my-gateway` rather than `/my-gateway`.
+
+### Processing pipeline
+
+```alloy
+loki.process "add_labels" {
+  forward_to = [loki.write.grafana_loki.receiver]
+
+  stage.regex {
+    expression = `^jvm \d+ \| .*? \| (?P<temp_level>[A-Z])\s+\[(?P<logger>.*?)\] \[(?P<log_time>.*?)\]: (?P<msg_content>.*)$`
+  }
+
+  stage.template {
+    source   = "level"
+    template = `{{ $l := .temp_level | trim }}{{ if eq $l "I" }}info{{ else if eq $l "W" }}warning{{ else if eq $l "E" }}error{{ else }}debug{{ end }}`
+  }
+
+  stage.logfmt {
+    source  = "msg_content"
+    mapping = { "trace_id" = "", "span_id" = "" }
+  }
+
+  stage.labels {
+    values = {
+      level    = "level",
+      logger   = "logger",
+      trace_id = "trace_id",
+    }
+  }
+
+  stage.output {
+    source = "msg_content"
+  }
+}
+
+loki.write "grafana_loki" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}
+```
+
+Stage-by-stage rationale:
+
+1. **`stage.regex`**: Ignition's default log format prefixes each line with `jvm <pid> | <timestamp> | <level-char> [<logger>] [<time>]: <message>`. This regex captures the level character, logger name, and message content as named groups. Without this stage, logs arrive as raw unstructured text with no level or logger labels.
+
+2. **`stage.template` (level normalization)**: The captured level character (`I`, `W`, `E`, `D`) is mapped to Loki's conventional level strings (`info`, `warning`, `error`, `debug`). This allows Grafana log panels to color-code lines by level and lets users filter with `{level="error"}` rather than needing to know the single-character codes.
+
+3. **`stage.logfmt`**: The message content produced by the OTel Logback appender embeds `trace_id` and `span_id` as logfmt key-value pairs when MDC capture is enabled. This stage extracts them so they are available as structured fields.
+
+4. **`stage.labels`**: Promotes `level`, `logger`, and `trace_id` from extracted fields to Loki index labels. `trace_id` as a label enables Grafana's trace-to-logs correlation: Tempo can link to the exact Loki stream for a given trace ID.
+
+5. **`stage.output`**: Sets the final log line to just the message content, discarding the `jvm <pid> | ...` prefix that was needed for parsing but adds noise to the stored record.
+
+## Kubernetes pipeline
+
+On Kubernetes Alloy runs as a DaemonSet, one replica per node. Each instance reads pod logs for the pods scheduled on that node. The Kubernetes pipeline adds filtering logic to control log volume from non-Ignition workloads that share the cluster.
+
+```alloy
+discovery.kubernetes "pods" {
+  role = "pod"
+  selectors {
+    role  = "pod"
+    field = "spec.nodeName=" + coalesce(sys.env("HOSTNAME"), constants.hostname)
+  }
+}
+
+discovery.relabel "pods" {
+  targets = discovery.kubernetes.pods.targets
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_phase"]
+    regex         = "Pending|Succeeded|Failed|Completed"
+    action        = "drop"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    target_label  = "node_name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app", "__tmp_controller_name", "__meta_kubernetes_pod_name"]
+    regex         = "^;*([^;]+)(;.*)?$"
+    action        = "replace"
+    target_label  = "app"
+  }
+}
+
+loki.source.kubernetes "pods" {
+  targets    = discovery.relabel.pods.output
+  forward_to = [loki.process.default.receiver]
+}
+```
+
+The `spec.nodeName` field selector is why Alloy runs as a DaemonSet: each pod only discovers and reads the pods on its own node, so there is no duplicate collection across replicas.
+
+The `Pending|Succeeded|Failed|Completed` drop rule in `discovery.relabel` prevents Alloy from trying to tail logs from pods that are not in a running state, which would produce errors and retries without any useful data.
+
+### Processing and filtering pipeline
+
+```alloy
+loki.process "default" {
+  // Drop Loki's own pod logs — high volume, self-referential noise
+  stage.match {
+    selector = `{app="loki"}`
+    action   = "drop"
+  }
+
+  // Drop Twingate operator non-error logs — operator is chatty at INFO level
+  stage.match {
+    selector = `{app=~"twingate.*"} !~ "(?i)(warn|error|fatal)"`
+    action   = "drop"
+  }
+
+  // Drop backend-gateway non-error logs — keep only actionable signal
+  stage.match {
+    selector = `{app=~".*backend.*"} !~ "(?i)(WARN|ERROR|FATAL)"`
+    action   = "drop"
+  }
+
+  // Aggregate multi-line entries (wrapper startup, JVM crash dumps)
+  stage.multiline {
+    firstline     = "^\\{|^\\d|^\\[|^[A-Z]{2,5}\\s"
+    max_wait_time = "3s"
+    max_lines     = 128
+  }
+
+  // Reformat JSON log lines from Ignition's logback JsonEncoder
+  // Scoped to the namespace where the gateway runs
+  stage.match {
+    selector = `{namespace="public-demo"} |~ "^{"`
+
+    stage.json {
+      expressions = {
+        level     = "level",
+        timestamp = "timestamp",
+        msg       = "message",
+        logger    = "loggerName",
+        thread    = "threadName",
+        throwable = "throwable",
+      }
+    }
+
+    stage.labels {
+      values = {
+        level = "",
+      }
+    }
+
+    stage.timestamp {
+      source = "timestamp"
+      format = "unix_ms"
+    }
+
+    stage.template {
+      source   = "output_line"
+      template = `{{ .level }} [{{ .thread }}] {{ .logger }} - {{ .msg }}{{ if .throwable }}\n{{ .throwable }}{{ end }}`
+    }
+
+    stage.output {
+      source = "output_line"
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "https://loki.your-domain.com/loki/api/v1/push"
+  }
+}
+```
+
+Filter and processing rationale:
+
+1. **Drop Loki's own logs**: Loki writes internal debug and scrape logs that are high volume and have no actionable content for gateway operators. Keeping them would inflate Loki storage and add noise to log queries.
+
+2. **Drop Twingate operator non-errors**: The Twingate VPN operator is chatty at INFO level, logging connectivity probes and status checks continuously. Only warnings and errors carry actionable signal. This drop rule reduces log volume significantly in clusters using Twingate without losing any information that would affect an alert or investigation.
+
+3. **Drop backend-gateway non-errors**: In the public-demo architecture, `backend` pods that run Ignition gateway instances in a non-primary role generate verbose INFO logs during normal operation. Keeping only WARN/ERROR/FATAL entries retains the signal an on-call engineer needs while substantially reducing storage costs.
+
+4. **Multiline aggregation**: Ignition's JVM process emits multi-line log entries for gateway startup (which prints configuration tables), JVM crash dumps, and exception stack traces. Without multiline aggregation each physical line becomes a separate Loki log entry, making stack traces impossible to query as a unit. The `firstline` pattern matches the start of a JSON object (`{`), a timestamp-prefixed line, a bracket-prefixed line, or an uppercase-word prefix (common Tanuki Wrapper format). The `max_wait_time` of 3 s and `max_lines` of 128 bound memory use during collection spikes.
+
+5. **JSON parsing (logback JsonEncoder)**: When the Ignition gateway is configured to use logback's `JsonEncoder`, log lines arrive as JSON objects with fields like `level`, `timestamp`, `message`, `loggerName`, and `throwable`. The `stage.json` block extracts these fields so `level` can become a Loki label and so the output line can be reformatted into a human-readable string. The `stage.match` selector `|~ "^{"` ensures this processing only applies to lines that are JSON objects, so it does not corrupt plain-text log lines from other containers in the same namespace. The namespace selector (`namespace="public-demo"`) further scopes it to avoid applying logback field names to containers with a different JSON schema.
+
+6. **Timestamp extraction**: The `stage.timestamp` block with `format = "unix_ms"` tells Loki to use the timestamp embedded in the JSON log record rather than the collection time. This matters when there is lag between log emission and collection, and it prevents out-of-order ingestion errors when the gateway emits log bursts during startup.

--- a/docs/guides/observability/metrics-stack.md
+++ b/docs/guides/observability/metrics-stack.md
@@ -12,7 +12,7 @@ This guide covers the collector and storage stack that receives the telemetry th
 The LGTM stack is a set of Grafana Labs components that together cover the four observability signals:
 
 | Component | Signal | Port |
-|---|---|---|
+| --- | --- | --- |
 | Grafana Alloy | Collector and router for all signals | 4317 (gRPC), 4318 (HTTP) |
 | Grafana Mimir | Metrics storage (Prometheus-compatible) | 9009 |
 | Grafana Loki | Log storage | 3100 |
@@ -227,11 +227,13 @@ On Kubernetes, the kube-prometheus-stack Helm chart installs Prometheus Operator
 ### When to use which
 
 Use the **Grafana LGTM stack** when:
+
 - Running Docker Compose on a developer workstation or a single VM.
 - You want long-term storage for all four signal types (metrics, logs, traces, profiles) from a single compose file.
 - You are not already running a Prometheus operator.
 
 Use the **kube-prometheus-stack** when:
+
 - You are deploying to a Kubernetes cluster that already runs or benefits from a Prometheus operator.
 - You want Kubernetes infrastructure metrics (node, pod, PVC utilization) alongside gateway metrics.
 - Metrics retention is short per-cluster and you remote-write to a central Prometheus-compatible store.

--- a/docs/guides/observability/metrics-stack.md
+++ b/docs/guides/observability/metrics-stack.md
@@ -1,0 +1,325 @@
+---
+sidebar_position: 3
+applies_to: [docker, kubernetes]
+---
+
+# Metrics and Log Stack
+
+This guide covers the collector and storage stack that receives the telemetry the gateway pushes after [Gateway Telemetry](./gateway-telemetry.md) wiring is complete. Two approaches are documented: the Grafana LGTM stack for Docker Compose environments, and the kube-prometheus-stack for Kubernetes clusters that already run a Prometheus operator.
+
+## Grafana LGTM stack (Docker Compose)
+
+The LGTM stack is a set of Grafana Labs components that together cover the four observability signals:
+
+| Component | Signal | Port |
+|---|---|---|
+| Grafana Alloy | Collector and router for all signals | 4317 (gRPC), 4318 (HTTP) |
+| Grafana Mimir | Metrics storage (Prometheus-compatible) | 9009 |
+| Grafana Loki | Log storage | 3100 |
+| Grafana Tempo | Trace storage | 3200 |
+| Grafana | Visualization and dashboards | 3000 |
+
+Pyroscope (profiles) is included in the compose file but is a separate topic.
+
+### Compose stack
+
+The following is a condensed version of the `observability-stack/docker-compose.yml` from the dawg-architecture-lab, showing the core services. Run this stack on the same Docker network as your Ignition gateways so Alloy is reachable at `alloy:4318`.
+
+```yaml
+services:
+  grafana:
+    image: grafana/grafana:main
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./config_files/grafana-config.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./grafana_dashboards:/var/lib/grafana/dashboards
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+    networks:
+      - monitoring
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    volumes:
+      - ./config_files/alloy-config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - "run"
+      - "--server.http.listen-addr=0.0.0.0:12345"
+      - "/etc/alloy/config.alloy"
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - monitoring
+
+  mimir:
+    image: grafana/mimir:3.0.0
+    container_name: mimir
+    command:
+      - "-config.file=/etc/mimir/mimir-config.yaml"
+    volumes:
+      - ./config_files/mimir-config.yaml:/etc/mimir/mimir-config.yaml
+      - mimir_data:/data
+    ports:
+      - "9009:9009"
+    networks:
+      - monitoring
+
+  loki:
+    image: grafana/loki:3.7.1
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./config_files/loki-config.yaml:/etc/loki/local-config.yaml
+    command:
+      - "-config.file=/etc/loki/local-config.yaml"
+    networks:
+      - monitoring
+
+  tempo:
+    image: grafana/tempo:2.10.0
+    container_name: tempo
+    command:
+      - "-config.file=/etc/tempo-config.yaml"
+    volumes:
+      - ./config_files/tempo-config.yaml:/etc/tempo-config.yaml
+    ports:
+      - "3200:3200"
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    name: monitoring
+    driver: bridge
+
+volumes:
+  grafana_data:
+  mimir_data:
+```
+
+The `monitoring` network is declared as an external network in the gateway compose file (the gateway's compose file joins it with `networks: monitoring: external: true`). This lets Alloy and the gateways communicate without putting everything in one compose file.
+
+### Alloy pipeline
+
+Alloy acts as a unified collector. It receives OTLP signals from the gateway, fans them out to the right storage backend, and also scrapes Prometheus-format metrics from other components.
+
+The core OTLP receiver in `alloy-config.alloy`:
+
+```alloy
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input,
+               otelcol.connector.servicegraph.default.input,
+               otelcol.connector.spanmetrics.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  timeout             = "5s"
+  send_batch_size     = 1000
+  send_batch_max_size = 5000
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    logs    = [otelcol.exporter.loki.to_loki.input]
+  }
+}
+
+otelcol.exporter.prometheus "default" {
+  forward_to                       = [prometheus.remote_write.default.receiver]
+  resource_to_telemetry_conversion = true
+}
+
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://mimir:9009/api/v1/push"
+  }
+}
+
+otelcol.exporter.otlp "tempo" {
+  timeout = "20s"
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure            = true
+      insecure_skip_verify = true
+    }
+  }
+}
+
+otelcol.exporter.loki "to_loki" {
+  forward_to = [loki.write.grafana_loki.receiver]
+}
+```
+
+Alloy also generates span metrics and service graphs from traces, forwarding them as additional metric series to Mimir. This gives you RED (rate, errors, duration) metrics derived from trace data without any application-side changes.
+
+For the log filtering and processing pipeline, see [Log Pipeline](./logs.md).
+
+### Grafana datasource provisioning
+
+Provision all four datasources in `grafana-config.yaml` with cross-linking enabled so Grafana can jump from a trace to its correlated logs and profiles:
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Mimir
+    type: prometheus
+    uid: PAE45454D0EDB9216
+    access: proxy
+    url: http://mimir:9009/prometheus
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    type: loki
+    uid: P8E80F9AEF21F6940
+    access: proxy
+    url: http://loki:3100
+    editable: true
+
+  - name: Tempo
+    type: tempo
+    uid: P214B5B846CF3925F
+    access: proxy
+    url: http://tempo:3200
+    editable: true
+    jsonData:
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: "PAE45454D0EDB9216"
+      tracesToLogsV2:
+        datasourceUid: "P8E80F9AEF21F6940"
+        filterByTraceID: true
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+      tracesToMetrics:
+        datasourceUid: "PAE45454D0EDB9216"
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+```
+
+The `tracesToLogsV2` configuration allows navigating from a Tempo trace directly to the correlated Loki log lines. The `tracesToMetrics` link navigates from a trace span to the corresponding metric panel in Mimir. These links work because the OTel agent attaches `trace_id` and `span_id` to log records (via MDC capture) and because Alloy promotes the same resource attributes to Prometheus labels.
+
+## kube-prometheus-stack (Kubernetes)
+
+On Kubernetes, the kube-prometheus-stack Helm chart installs Prometheus Operator, Prometheus, Grafana, and Alertmanager as a bundle. This is the recommended approach when you already operate a Prometheus-based observability platform or when you want native Kubernetes resource monitoring alongside gateway metrics.
+
+### When to use which
+
+Use the **Grafana LGTM stack** when:
+- Running Docker Compose on a developer workstation or a single VM.
+- You want long-term storage for all four signal types (metrics, logs, traces, profiles) from a single compose file.
+- You are not already running a Prometheus operator.
+
+Use the **kube-prometheus-stack** when:
+- You are deploying to a Kubernetes cluster that already runs or benefits from a Prometheus operator.
+- You want Kubernetes infrastructure metrics (node, pod, PVC utilization) alongside gateway metrics.
+- Metrics retention is short per-cluster and you remote-write to a central Prometheus-compatible store.
+
+### Scraping the OTel agent's Prometheus endpoint
+
+The kube-prometheus-stack does not receive OTLP push from the gateway. Instead, when the OTel operator injects the agent in-cluster (via an `Instrumentation` CRD), the agent stands up a Prometheus `/metrics` endpoint on port 9000. The kube-prometheus-stack scrapes that endpoint via a `PodMonitor`.
+
+The `Instrumentation` CRD that enables the Prometheus exporter alongside OTLP:
+
+```yaml
+# Forward link: in-cluster OTel operator pattern (future guide)
+# otel.metrics.exporter is set to "otlp,prometheus" here
+# OTEL_EXPORTER_PROMETHEUS_PORT: "9000"
+```
+
+The `PodMonitor` that targets port 9000 on gateway pods:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: ignition-metrics
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: my-release
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values: [frontend, backend]
+  podMetricsEndpoints:
+    - path: /metrics
+      interval: 15s
+      relabelings:
+        # Target the gateway container's OTel Prometheus exporter on port 9000
+        - sourceLabels: [__meta_kubernetes_pod_ip]
+          targetLabel: __address__
+          replacement: "$1:9000"
+          action: replace
+      metricRelabelings:
+        # Keep only Ignition-relevant metric families
+        - sourceLabels: [__name__]
+          regex: "ignition_.*|perspective_.*|databases_.*|jvm_memory.*|jvm_threads.*|process_cpu.*|process_uptime.*"
+          action: keep
+```
+
+The `metricRelabelings` block is important: the OTel agent exports a large number of JVM and HTTP metrics from instrumented libraries. Keeping only the `ignition_*`, `perspective_*`, and `databases_*` families (plus essential JVM metrics) prevents high cardinality from inflating storage and query costs.
+
+### kube-prometheus-stack Helm values
+
+The public-demo deployment runs Prometheus in agent mode: short local retention (2 h) with remote write to a central store. Key values from `common-values.yaml`:
+
+```yaml
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      retention: 2h
+      remoteWrite:
+        - url: https://prometheus.your-domain.com/api/v1/write
+          writeRelabelConfigs:
+            # Drop verbose container metrics, keep essentials
+            - sourceLabels: [__name__]
+              regex: 'container_(tasks_state|memory_failures_total|fs_.*|network_.*)'
+              action: drop
+            # Drop high-cardinality kube labels
+            - sourceLabels: [__name__]
+              regex: 'kube_(pod_labels|pod_annotations)'
+              action: drop
+            # Drop internal scrape metrics
+            - sourceLabels: [__name__]
+              regex: '(go_|promhttp_).*'
+              action: drop
+  grafana:
+    enabled: false  # Use a shared Grafana instance instead
+  alertmanager:
+    enabled: false
+  # Disable control plane exporters (require kube-system access)
+  kubeControllerManager:
+    enabled: false
+  kubeScheduler:
+    enabled: false
+  kubeProxy:
+    enabled: false
+  kubeEtcd:
+    enabled: false
+```
+
+The in-cluster OTel operator injection and the full Instrumentation CRD are a forward topic. See [Gateway Telemetry](./gateway-telemetry.md) for the agent wiring concepts.

--- a/docs/reference/architecture-index.md
+++ b/docs/reference/architecture-index.md
@@ -12,7 +12,7 @@ Read the mental model first, then size and deploy a gateway, then add observabil
 2. [Kubernetes concepts for Ignition](../guides/kubernetes/concepts.md): the StatefulSet, PVC, Service, and Secret choices behind the Helm chart.
 3. [Kubernetes Sizing Reference](./kubernetes-sizing.md): CPU, memory, heap, and PVC starting points.
 4. [Helm Ignition Lab](../labs/helm-ignition-lab.md): deploy a gateway on a cluster end to end.
-5. [Observability for Ignition](../guides/observability/intro.md): what to monitor and how the stack fits together.
+5. [Observability for Ignition](../guides/observability/intro.md): what to monitor and how the stack fits together. Start with [Gateway Telemetry](../guides/observability/gateway-telemetry.md) to attach the OTel agent.
 
 :::note Managed and self-hosted clusters use the same path
 
@@ -28,4 +28,4 @@ Read the container architecture first, then layer in operations and observabilit
 2. [The Compose Architecture](../guides/docker/compose-architecture.md) and [Volume Strategy](../guides/docker/volume-strategy.md): how the stack is wired and where data lives.
 3. [Licensing in Containers](../guides/docker/licensing.md) and [Day-Two Operations](../guides/docker/day-two-operations.md): running a licensed gateway and keeping it healthy.
 4. [Docker Ignition Lab](../labs/docker-ignition-lab.md): stand up a gateway from the template.
-5. [Observability for Ignition](../guides/observability/intro.md): the observability patterns apply to Compose deployments too.
+5. [Observability for Ignition](../guides/observability/intro.md): the observability patterns apply to Compose deployments too. Start with [Gateway Telemetry](../guides/observability/gateway-telemetry.md) to attach the OTel agent.

--- a/docs/reference/ignition-otel-properties.md
+++ b/docs/reference/ignition-otel-properties.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 6
+---
+
+# OTel Properties Reference
+
+This page lists the OpenTelemetry Java agent properties used to instrument an Ignition gateway. Properties appear in `otel-agent.properties` on bare-metal installs or as `-Dotel.*` JVM arguments in the Docker Compose `command:` block.
+
+For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-telemetry.md).
+
+## Identity and resource attributes
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.service.name` | `my-gateway` | The service name attached to every metric, trace, and log record. Appears as the `service.name` resource attribute. Should match the gateway name for easy correlation. |
+| `otel.resource.attributes` | `gateway=gw1,environment=Production,ignition.version=8.3.6` | Comma-separated key=value pairs added to every signal as resource attributes. Useful for filtering in Grafana across multiple gateways or environments. |
+
+## Exporter protocol
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.exporter.otlp.protocol` | `http/protobuf` | Wire protocol for OTLP export. `http/protobuf` sends to port 4318. Use `grpc` for port 4317. This is the default protocol for all signal types unless overridden per-signal below. |
+
+## Agent logging
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.javaagent.logging` | `none` | Controls the agent's own log output. `none` silences startup messages; `simple` enables them for debugging. Does not affect Ignition's application log forwarding. |
+
+## Metrics
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.metrics.exporter` | `otlp` | Metrics export backend. Use `otlp` to push over OTLP. The gateway does not expose a native Prometheus endpoint; set `prometheus` here only if the agent should additionally stand up its own `/metrics` scrape endpoint (used in the Kubernetes in-cluster pattern on port 9000). |
+| `otel.exporter.otlp.metrics.protocol` | `http/protobuf` | Per-signal protocol override for metrics. |
+| `otel.exporter.otlp.metrics.endpoint` | `http://alloy:4318/v1/metrics` | OTLP endpoint for metrics. |
+| `otel.metric.export.interval` | `5000` | Milliseconds between metric export cycles. 5000 ms (5 s) is a good balance between resolution and collector load. |
+| `otel.instrumentation.dropwizard-metrics.enabled` | `true` | **Required for Ignition metrics.** Ignition's internal performance counters use the Dropwizard/Codahale metrics library. Without this flag the most useful Ignition-specific gauges (tag write throughput, Perspective sessions, thread pool stats) are not captured. |
+| `otel.instrumentation.jdbc-datasource.enabled` | `true` | Enables per-connection-pool metrics for every database connection configured in the Ignition gateway (query latency, pool utilization, connection counts). |
+| `otel.instrumentation.runtime-telemetry.enabled` | `false` | JVM runtime telemetry (generic). Disabled when Dropwizard instrumentation is active to avoid duplicate JVM metric series. |
+| `otel.instrumentation.runtime-telemetry-java17.enabled` | `false` | Java 17 JVM telemetry variant. Disabled for the same deduplication reason as above. |
+
+## Logs
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.logs.exporter` | `otlp` | Log export backend. |
+| `otel.exporter.otlp.logs.endpoint` | `http://alloy:4318/v1/logs` | OTLP endpoint for logs. |
+| `otel.instrumentation.logback-appender.enabled` | `true` | Captures every log entry written through Ignition's Logback appender and forwards it as an OTLP log record. This is the primary source of gateway log data in Loki. |
+| `otel.instrumentation.logback-mdc.enabled` | `true` | Includes Logback MDC fields (such as trace ID and span ID) in forwarded log records, enabling trace-to-log correlation in Grafana. |
+| `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes` | `*` | Captures all MDC attributes as log record attributes. The `*` wildcard captures everything; narrow to specific keys if cardinality is a concern. |
+
+## Traces
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.traces.exporter` | `otlp` | Trace export backend. |
+| `otel.exporter.otlp.traces.protocol` | `http/protobuf` | Per-signal protocol override for traces. |
+| `otel.exporter.otlp.traces.endpoint` | `http://alloy:4318/v1/traces` | OTLP endpoint for traces. |
+
+## Manual method instrumentation
+
+| Property | Example value | Description |
+|---|---|---|
+| `otel.instrumentation.methods.include` | `com.inductiveautomation.ignition.gateway.tags.managed.ManagedTagProvider[browseTagsAsync,readAsync]` | Semicolon-separated list of `FullyQualifiedClassName[method1,method2]` entries. Adds spans for specific internal Ignition methods that are not instrumented by default. Useful for tracing tag read/write paths. See the comment block in `otel-agent.properties` for a full example targeting the tag provider stack. |
+
+## Pyroscope profiling (optional)
+
+The Pyroscope integration requires the `pyroscope-otel.jar` extension JAR alongside the main agent. These properties are set as environment variables (not in `otel-agent.properties`) when using the extension:
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_JAVAAGENT_EXTENSIONS` | Path to `pyroscope-otel.jar`. Activates the Pyroscope OTel bridge. |
+| `PYROSCOPE_SERVER_ADDRESS` | Address of the Pyroscope server (e.g. `http://pyroscope:4040`). |
+| `PYROSCOPE_APPLICATION_NAME` | Application name label in Pyroscope, typically matches the gateway name. |
+| `PYROSCOPE_FORMAT` | Profile format. `jfr` is recommended for the Grafana Pyroscope datasource. |
+
+Profiling is a separate concern from the core metrics/traces/logs pipeline and is covered as a future topic in this pillar.

--- a/docs/reference/ignition-otel-properties.md
+++ b/docs/reference/ignition-otel-properties.md
@@ -11,26 +11,26 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 ## Identity and resource attributes
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.service.name` | `my-gateway` | The service name attached to every metric, trace, and log record. Appears as the `service.name` resource attribute. Should match the gateway name for easy correlation. |
 | `otel.resource.attributes` | `gateway=gw1,environment=Production,ignition.version=8.3.6` | Comma-separated key=value pairs added to every signal as resource attributes. Useful for filtering in Grafana across multiple gateways or environments. |
 
 ## Exporter protocol
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.exporter.otlp.protocol` | `http/protobuf` | Wire protocol for OTLP export. `http/protobuf` sends to port 4318. Use `grpc` for port 4317. This is the default protocol for all signal types unless overridden per-signal below. |
 
 ## Agent logging
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.javaagent.logging` | `none` | Controls the agent's own log output. `none` silences startup messages; `simple` enables them for debugging. Does not affect Ignition's application log forwarding. |
 
 ## Metrics
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.metrics.exporter` | `otlp` | Metrics export backend. Use `otlp` to push over OTLP. The gateway does not expose a native Prometheus endpoint; set `prometheus` here only if the agent should additionally stand up its own `/metrics` scrape endpoint (used in the Kubernetes in-cluster pattern on port 9000). |
 | `otel.exporter.otlp.metrics.protocol` | `http/protobuf` | Per-signal protocol override for metrics. |
 | `otel.exporter.otlp.metrics.endpoint` | `http://alloy:4318/v1/metrics` | OTLP endpoint for metrics. |
@@ -43,7 +43,7 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 ## Logs
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.logs.exporter` | `otlp` | Log export backend. |
 | `otel.exporter.otlp.logs.endpoint` | `http://alloy:4318/v1/logs` | OTLP endpoint for logs. |
 | `otel.instrumentation.logback-appender.enabled` | `true` | Captures every log entry written through Ignition's Logback appender and forwards it as an OTLP log record. This is the primary source of gateway log data in Loki. |
@@ -53,7 +53,7 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 ## Traces
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.traces.exporter` | `otlp` | Trace export backend. |
 | `otel.exporter.otlp.traces.protocol` | `http/protobuf` | Per-signal protocol override for traces. |
 | `otel.exporter.otlp.traces.endpoint` | `http://alloy:4318/v1/traces` | OTLP endpoint for traces. |
@@ -61,7 +61,7 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 ## Manual method instrumentation
 
 | Property | Example value | Description |
-|---|---|---|
+| --- | --- | --- |
 | `otel.instrumentation.methods.include` | `com.inductiveautomation.ignition.gateway.tags.managed.ManagedTagProvider[browseTagsAsync,readAsync]` | Semicolon-separated list of `FullyQualifiedClassName[method1,method2]` entries. Adds spans for specific internal Ignition methods that are not instrumented by default. Useful for tracing tag read/write paths. See the comment block in `otel-agent.properties` for a full example targeting the tag provider stack. |
 
 ## Pyroscope profiling (optional)
@@ -69,7 +69,7 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 The Pyroscope integration requires the `pyroscope-otel.jar` extension JAR alongside the main agent. These properties are set as environment variables (not in `otel-agent.properties`) when using the extension:
 
 | Environment variable | Description |
-|---|---|
+| --- | --- |
 | `OTEL_JAVAAGENT_EXTENSIONS` | Path to `pyroscope-otel.jar`. Activates the Pyroscope OTel bridge. |
 | `PYROSCOPE_SERVER_ADDRESS` | Address of the Pyroscope server (e.g. `http://pyroscope:4040`). |
 | `PYROSCOPE_APPLICATION_NAME` | Application name label in Pyroscope, typically matches the gateway name. |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -39,7 +39,11 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "Observability",
           link: { type: "doc", id: "guides/observability/intro" },
-          items: [],
+          items: [
+            "guides/observability/gateway-telemetry",
+            "guides/observability/metrics-stack",
+            "guides/observability/logs",
+          ],
         },
         {
           type: "category",
@@ -68,6 +72,7 @@ const sidebars: SidebarsConfig = {
       label: "Reference",
       items: [
         "reference/architecture-index",
+        "reference/ignition-otel-properties",
         "reference/git-style-guide",
         "reference/resource-collections",
         "reference/docker-command-reference",


### PR DESCRIPTION
### Background

Round one of the DevOps content venture builds out the Observability pillar (Phases 2 and 3 of the plan). Observability is the richest and most deployment-agnostic theme in the source material, and gateway telemetry is the single highest-leverage page because the OpenTelemetry Java agent wiring is identical across Docker, Kubernetes, and bare-metal.

### Changes

Four new pages plus wiring, all grounded in the `dawg-architecture-lab` and `publicdemo-k8s` source repos:

- **`guides/observability/gateway-telemetry.md`** (flagship): attaching the OTel Java agent to a gateway. Leads with the deployment-agnostic concept, then the Docker Compose `-javaagent` wiring, then the bare-metal `ignition.conf` + `otel-agent.properties` path, then a brief forward reference to the Kubernetes in-cluster auto-inject pattern.
- **`guides/observability/metrics-stack.md`**: the Grafana LGTM compose stack (Alloy/Mimir/Loki/Tempo/Grafana) with datasource cross-linking, plus the kube-prometheus-stack alternative and a "when to use which" decision.
- **`guides/observability/logs.md`**: the Loki + Alloy pipeline for Docker and Kubernetes, with per-stage rationale for the log filtering and logback-JSON parsing.
- **`reference/ignition-otel-properties.md`**: a reference table of every `otel.*` property used, linking back to the guide.
- Fills the `observability/intro` landing page links, registers all pages in `sidebars.ts`, and adds telemetry to both `architecture-index` platform paths.

### Reviewer Notes

Every config block was copied from the actual source-repo files and re-verified against them (the `-javaagent` flags, `otel-agent.properties`, the `ignition.conf` wrapper indexes 20/25, the Alloy `remote_write` URL, the PodMonitor port-9000 keep-regex). Internal hostnames were genericized. The pages deliberately present the **OTel agent** as the telemetry method and do not imply Ignition exposes a native Prometheus endpoint (that remains an open feature request). Build passes clean with `onBrokenLinks: throw` and zero broken-anchor warnings.