### PR TITLE
feat: add kubernetes pillar (s3 modules, secrets, applicationsets, config sync)

### DIFF
--- a/docs/guides/kubernetes/config-sync.md
+++ b/docs/guides/kubernetes/config-sync.md
@@ -1,0 +1,157 @@
+---
+sidebar_position: 6
+applies_to: [kubernetes]
+---
+
+# Config Sync: Keeping Gateways in Sync with Git
+
+Ignition stores projects, tag configurations, and resource configuration on disk in the gateway's data directory. In a Kubernetes deployment these files live inside a StatefulSet pod's PVC. The challenge: how do you update those files when a developer merges a change, without replacing pods or manually copying files?
+
+The recommended approach is the [Stoker operator](../../tools/stoker-operator.md), which uses a `GatewaySync` custom resource to keep gateways continuously in sync with a Git repository. After the initial sync, Stoker pushes changes to running gateways by triggering Ignition's built-in project and config scan APIs - the gateway reloads updated resources without restarting.
+
+## How Stoker Config Sync Works
+
+Stoker uses a controller + agent architecture:
+
+- The **controller** watches `GatewaySync` custom resources, resolves git refs, and discovers gateway pods by their labels
+- The **agent** runs as a native sidecar inside gateway pods, clones the repo, and syncs files to the gateway's data directory
+- The gateway picks up the changes via its scan APIs (`/data/api/v1/scan/projects` and `/data/api/v1/scan/config`) without a pod restart
+
+Communication between controller and agent is via Kubernetes ConfigMaps - no shared PVC required. See the [Stoker operator page](../../tools/stoker-operator.md) for installation, CRD field reference, and webhook receiver setup.
+
+## The GatewaySync Resource
+
+The `GatewaySync` CRD is the primary configuration surface. Each resource targets a specific deployment's pods, names a git source, defines per-gateway **profiles** (source-to-destination path mappings), and optionally applies **patches** to config files (such as setting the gateway system name from a pod variable).
+
+### Worked example: PublicDemo
+
+From `charts/public-demo/templates/gatewaysync.yaml`, the PublicDemo platform deploys a single `GatewaySync` that drives both the frontend and backend gateways via two profiles:
+
+```yaml
+apiVersion: stoker.io/v1alpha1
+kind: GatewaySync
+metadata:
+  name: public-demo-sync
+  namespace: public-demo
+spec:
+  git:
+    repo: "org-147873951@github.com:inductive-automation/publicdemo-all.git"
+    ref: "2.3.10"    # updated by Kargo on each promotion
+    auth:
+      sshKey:
+        secretRef:
+          name: git-sync-secret
+          key: ssh
+  polling:
+    enabled: true
+    interval: "5m"   # recovery safety net; primary trigger is webhook
+  agent:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi
+  gateway:
+    port: 8043
+    tls: true
+    api:
+      secretName: ignition-api-key
+      secretKey: apiKey
+  sync:
+    defaults:
+      excludePatterns:
+        - "**/tag-*/MQTT Engine"
+        - "**/tag-*/MQTT Transmission"
+        - "**/tag-*/System"
+        - "**/gateway-network-incoming"
+    profiles:
+      frontend:
+        vars:
+          gatewayName: "public-demo-fe"
+        mappings:
+          - source: "services/ignition-frontend/projects"
+            destination: "projects"
+          - source: "services/ignition-frontend/config/resources/core"
+            destination: "config/resources/core"
+          - source: "services/ignition-frontend/config/resources/external"
+            destination: "config/resources/external"
+          - source: "services/ignition-frontend/config/resources/dev-us-west-2"
+            destination: "config/resources/dev-us-west-2"
+            patches:
+              - file: "ignition/system-properties/config.json"
+                set:
+                  systemName: "{{.Vars.gatewayName}}-{{.PodOrdinal}}"
+          - source: ".versions.json"
+            destination: ".versions.json"
+      backend:
+        vars:
+          gatewayName: "public-demo-be"
+        mappings:
+          - source: "services/ignition-backend/projects"
+            destination: "projects"
+          - source: "services/ignition-backend/config/resources/core"
+            destination: "config/resources/core"
+          - source: "services/ignition-backend/config/resources/external"
+            destination: "config/resources/external"
+          - source: "services/ignition-backend/config/resources/dev-us-west-2"
+            destination: "config/resources/dev-us-west-2"
+          - source: ".versions.json"
+            destination: ".versions.json"
+```
+
+Key things to observe in this resource:
+
+- **SSH auth** via a Kubernetes Secret (`git-sync-secret` with key `ssh`). This secret is created by the ExternalSecret wiring described in [External Secrets](./external-secrets.md).
+- **Polling as a safety net**: the 5-minute polling interval catches any missed webhook events, but the primary trigger in production is the Stoker webhook receiver responding to Kargo promotion events.
+- **Exclude patterns** at `sync.defaults` apply to every profile; they prevent Stoker from overwriting runtime-managed files like MQTT Engine tag providers and incoming Gateway Network connections.
+- **Patches** on a mapping: the frontend's `dev-us-west-2` mapping patches `systemName` in `ignition/system-properties/config.json` using the pod's ordinal index, producing stable per-pod system names (`public-demo-fe-0`, `public-demo-fe-1`, etc.) without duplicating config files.
+- **Pod labels** are how the controller finds gateway pods. Pods carry annotations like `stoker.io/inject: "true"` and `stoker.io/cr-name: "public-demo-sync"` and `stoker.io/profile: "frontend"` so the controller knows which profile to apply to which pod.
+
+### Enabling Stoker per environment
+
+Stoker is disabled by default in the chart's `values.yaml` and enabled per environment via values overlays:
+
+```yaml
+# values/public-demo/prod/environment-values.yaml
+stoker:
+  enabled: true
+  name: public-demo-sync-prod
+```
+
+The git ref that Stoker tracks is updated separately by Kargo as part of the promotion pipeline:
+
+```yaml
+# values/public-demo/prod/us-west-2/values.yaml (after a Kargo promotion)
+git:
+  ref: 2.3.10
+```
+
+### Seen in the wild: conf-proveit26
+
+The same `GatewaySync` pattern appears in the `conf-proveit26-platform` self-hosted IIoT deployment. That resource adds `knownHosts` to the SSH auth block and uses `vars` to template per-site configuration (MQTT edge node IDs, system names) across many gateways from a single resource. It demonstrates that the same CRD scales from two gateways to dozens.
+
+## Fallback: git-sync with API-triggered Scans
+
+Before Stoker, the platform used a git-sync init container that continuously polled the application repo and called the Ignition scan APIs when it detected a new commit hash. This approach is still in use in environments where Stoker is not yet enabled.
+
+The fallback runs as a long-lived init container (`restartPolicy: Always`) using the `registry.k8s.io/git-sync/git-sync:v4.6.0` image. On each poll cycle, `sync-entrypoint.sh` runs `git-sync --one-time` to fetch the latest ref, then calls `sync-files.sh` which:
+
+1. Copies projects and config resources from the cloned repo to a staging directory
+2. Applies exclude patterns to protect runtime-managed files
+3. Normalizes gateway system names in `ignition/system-properties/config.json`
+4. Atomically swaps the staging directory into place (delete old, copy new)
+5. Calls `POST /data/api/v1/scan/projects` and `POST /data/api/v1/scan/config` to trigger reload
+
+Hash-based change detection (`GITSYNC_HASH` vs a stored hash file) prevents the scan from firing on every poll when nothing has changed.
+
+The git-sync approach requires volumes (`git-secret`, `ignition-api-key-secret`, `git-volume`, `sync-scripts`) mounted into the init container and is more complex to configure than a Stoker `GatewaySync` resource. Prefer Stoker for new deployments.
+
+## Further Reading
+
+- [Stoker operator page](../../tools/stoker-operator.md): installation, full CRD field reference, webhook receiver, Helm values
+- [Stoker upstream docs](https://ia-eknorr.github.io/stoker-operator/): quickstart, installation reference
+- [Ignition scan APIs](https://docs.inductiveautomation.com/docs/8.3/): the `/data/api/v1/scan/projects` and `/data/api/v1/scan/config` endpoints that Stoker calls after syncing
+
+<!-- VERIFY: confirm the Ignition 8.3 REST scan API endpoint paths (/data/api/v1/scan/projects and /data/api/v1/scan/config) are documented at docs.ia.io and link to the correct 8.3 page -->

--- a/docs/guides/kubernetes/config-sync.md
+++ b/docs/guides/kubernetes/config-sync.md
@@ -153,5 +153,3 @@ The git-sync approach requires volumes (`git-secret`, `ignition-api-key-secret`,
 - [Stoker operator page](../../tools/stoker-operator.md): installation, full CRD field reference, webhook receiver, Helm values
 - [Stoker upstream docs](https://ia-eknorr.github.io/stoker-operator/): quickstart, installation reference
 - [Ignition scan APIs](https://docs.inductiveautomation.com/docs/8.3/): the `/data/api/v1/scan/projects` and `/data/api/v1/scan/config` endpoints that Stoker calls after syncing
-
-<!-- VERIFY: confirm the Ignition 8.3 REST scan API endpoint paths (/data/api/v1/scan/projects and /data/api/v1/scan/config) are documented at docs.ia.io and link to the correct 8.3 page -->

--- a/docs/guides/kubernetes/external-modules-s3.md
+++ b/docs/guides/kubernetes/external-modules-s3.md
@@ -92,6 +92,7 @@ pd83-<env>-ignition-modules-<region-short>
 ```
 
 Examples:
+
 - `pd83-prd-ignition-modules-us` (prod, us-west-2)
 - `pd83-dev-ignition-modules-us` (dev, us-west-2)
 

--- a/docs/guides/kubernetes/external-modules-s3.md
+++ b/docs/guides/kubernetes/external-modules-s3.md
@@ -116,8 +116,6 @@ The prod US-West-2 region uses `pd83-prd-ignition-modules-us` in `us-west-2`.
 
 The CSI driver requires IAM permissions to access the bucket. The Mountpoint S3 CSI Driver documentation describes the required IAM policy and recommended IRSA (IAM Roles for Service Accounts) approach.
 
-<!-- VERIFY: confirm whether the IRSA setup for s3.csi.aws.com is documented in bootstrap.md or another doc; bootstrap.md mentions it's installed by the cloud team but does not document the IAM policy itself -->
-
 ## On other platforms and bare-metal
 
 The `s3.csi.aws.com` CSI driver is AWS-specific. On other Kubernetes distributions:

--- a/docs/guides/kubernetes/external-modules-s3.md
+++ b/docs/guides/kubernetes/external-modules-s3.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 3
+applies_to: [kubernetes]
+---
+
+# External Ignition Modules from S3
+
+Ignition modules (`.modl` files) are typically installed directly into a gateway's data directory. In a Kubernetes environment where multiple gateways share the same set of third-party modules, installing modules independently into each pod's PVC means maintaining them in multiple places and replacing pods to update them. The S3 module pattern solves both problems.
+
+## How It Works
+
+The [Ignition Helm chart](https://charts.ia.io) supports an `externalModules` configuration that mounts a PersistentVolume (PV) containing `.modl` files into the gateway pod's modules directory. When gateways share a single PV backed by an S3 bucket:
+
+- The module files live in S3, not inside any pod
+- All gateways in the namespace read from the same PV
+- Updating a module means uploading a new `.modl` to the bucket - no pod replacement required for the file to become available on the next gateway scan
+- The PV access mode is `ReadOnlyMany`, so multiple pods can mount it simultaneously
+
+The chart creates a dedicated PersistentVolume and PersistentVolumeClaim when S3 modules are enabled. The PV uses the AWS Mountpoint S3 CSI Driver (`s3.csi.aws.com`) to map the bucket directly as a filesystem. The PVC name (`s3-modules`) is the shared reference that every gateway sub-chart binds to.
+
+### Backend creates, frontend mounts
+
+In a two-gateway deployment (frontend + backend), one gateway is responsible for creating the PVC (`createOptions.accessMode: ReadOnlyMany`) while the other gateways mount the same PVC by name without creating their own. This is controlled through the `externalModules` values block on each gateway.
+
+From `charts/public-demo/values.yaml`:
+
+```yaml
+# Backend creates the PVC with ReadOnlyMany access
+backend:
+  gateway:
+    externalModules:
+      enabled: true
+      pvcName: s3-modules
+      mountReadOnly: false
+      createOptions:
+        accessMode: ReadOnlyMany
+        size: 1Gi
+        other:
+          storageClassName: ""
+
+# Frontend mounts the same PVC (no createOptions = no PVC creation)
+frontend:
+  gateway:
+    externalModules:
+      enabled: true
+      pvcName: s3-modules
+      mountReadOnly: false
+      createOptions: {}
+```
+
+The underlying PersistentVolume is rendered by `charts/public-demo/templates/s3-modules-pv.yaml` and binds the `s3-modules` PVC to the bucket:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: <namespace>-s3-modules
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadOnlyMany
+  storageClassName: ""
+  claimRef:
+    namespace: <namespace>
+    name: s3-modules
+  mountOptions:
+    - region <region>
+  csi:
+    driver: s3.csi.aws.com
+    volumeHandle: <namespace>-s3-modules-vol
+    volumeAttributes:
+      bucketName: <bucket-name>
+```
+
+## On AWS (what we run)
+
+### Prerequisites
+
+The Mountpoint S3 CSI Driver must be installed on the cluster before enabling S3 modules. Verify with:
+
+```bash
+kubectl get csidrivers | grep s3
+```
+
+### Bucket naming
+
+From `docs/bootstrap.md`, the PublicDemo bucket naming convention is:
+
+```text
+pd83-<env>-ignition-modules-<region-short>
+```
+
+Examples:
+- `pd83-prd-ignition-modules-us` (prod, us-west-2)
+- `pd83-dev-ignition-modules-us` (dev, us-west-2)
+
+Create the bucket and configure it in the region's values file:
+
+```bash
+aws s3 mb s3://pd83-<env>-ignition-modules-<region-short> --region <region>
+```
+
+Then set the values in `values/<chart>/<env>/<region>/values.yaml`:
+
+```yaml
+s3Modules:
+  enabled: true
+  bucketName: pd83-<env>-ignition-modules-<region-short>
+  region: <region>
+```
+
+The prod US-West-2 region uses `pd83-prd-ignition-modules-us` in `us-west-2`.
+
+### IAM permissions
+
+The CSI driver requires IAM permissions to access the bucket. The Mountpoint S3 CSI Driver documentation describes the required IAM policy and recommended IRSA (IAM Roles for Service Accounts) approach.
+
+<!-- VERIFY: confirm whether the IRSA setup for s3.csi.aws.com is documented in bootstrap.md or another doc; bootstrap.md mentions it's installed by the cloud team but does not document the IAM policy itself -->
+
+## On other platforms and bare-metal
+
+The `s3.csi.aws.com` CSI driver is AWS-specific. On other Kubernetes distributions:
+
+- **GKE**: Use the GCS FUSE CSI driver with a GCS bucket as the backend
+- **AKS**: Use the Azure Blob Storage CSI driver
+- **Bare-metal / on-premises**: A shared NFS or CephFS volume with `ReadOnlyMany` access achieves the same topology - one writer that places `.modl` files, many readers that mount the same PV
+
+The values structure (`externalModules.pvcName`, `createOptions.accessMode`) is the same regardless of the storage backend. Only the PV spec changes.
+
+## Seen in the wild
+
+The same S3 module pattern with identical `s3-modules-pv.yaml` template appears in the `conf-proveit26-platform` self-hosted deployment, where `proveit-prd-ignition-modules` is the production bucket. That deployment uses the same `s3.csi.aws.com` driver and `ReadOnlyMany` access mode.

--- a/docs/guides/kubernetes/external-secrets.md
+++ b/docs/guides/kubernetes/external-secrets.md
@@ -9,7 +9,7 @@ Kubernetes Secrets are base64-encoded, not encrypted at rest by default, and hav
 
 For Ignition specifically, the secrets that need this treatment are:
 
-- **License activation** - the license key and activation token that Ignition reads at startup (see [Licensing](https://docs.inductiveautomation.com/docs/8.3/platform-concepts/modules-and-licensing/leased-licensing) for the activation model)
+- **License activation** - the license key and activation token that Ignition reads at startup (see [Licensing](https://docs.inductiveautomation.com/docs/8.3/platform/licensing-and-activation) for the activation model)
 - **Git credentials** - the SSH key the git-sync sidecar uses to clone the application repo
 - **Ignition API key** - the bearer token Stoker and git-sync use to call the gateway's REST API
 - **Gateway admin password** - the initial admin credential set during commissioning
@@ -50,8 +50,6 @@ spec:
 ```
 
 The IRSA binding lives in the cluster's IAM configuration (managed by the cloud team), not in this resource. The convention for secret names in AWS Secrets Manager is `publicdemo/{secret-name}`, so all secrets for this application live under a single path prefix.
-
-<!-- VERIFY: confirm the exact IRSA IAM role ARN or annotation pattern lives in the cluster-config chart or EKS setup docs, not in the external-secrets chart values -->
 
 ### ExternalSecrets in the Helm chart
 
@@ -167,4 +165,4 @@ On bare-metal clusters without a cloud secret store, [Sealed Secrets](https://gi
 ## Further reading
 
 - [External Secrets Operator documentation](https://external-secrets.io/latest/)
-- [Ignition leased licensing](https://docs.inductiveautomation.com/docs/8.3/platform-concepts/modules-and-licensing/leased-licensing)
+- [Ignition leased licensing](https://docs.inductiveautomation.com/docs/8.3/platform/licensing-and-activation)

--- a/docs/guides/kubernetes/external-secrets.md
+++ b/docs/guides/kubernetes/external-secrets.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 4
+applies_to: [kubernetes]
+---
+
+# External Secrets for Ignition on Kubernetes
+
+Kubernetes Secrets are base64-encoded, not encrypted at rest by default, and have no built-in rotation. Cloud secret stores (AWS Secrets Manager, GCP Secret Manager, HashiCorp Vault) provide encryption, rotation policies, and fine-grained access control. The [External Secrets Operator](https://external-secrets.io) bridges the gap: it reads from your cloud store and writes the result into ordinary Kubernetes Secrets that pods consume normally.
+
+For Ignition specifically, the secrets that need this treatment are:
+
+- **License activation** - the license key and activation token that Ignition reads at startup (see [Licensing](https://docs.inductiveautomation.com/docs/8.3/platform-concepts/modules-and-licensing/leased-licensing) for the activation model)
+- **Git credentials** - the SSH key the git-sync sidecar uses to clone the application repo
+- **Ignition API key** - the bearer token Stoker and git-sync use to call the gateway's REST API
+- **Gateway admin password** - the initial admin credential set during commissioning
+
+## How It Works
+
+Two resources coordinate the sync:
+
+**ClusterSecretStore** is a cluster-scoped resource that authenticates once to the external provider and makes that connection available to all namespaces. You configure it with IAM credentials, a service account annotation (IRSA on EKS), or a static API token depending on the provider.
+
+**ExternalSecret** is a namespace-scoped resource that says "pull these specific properties from this store and write them into a Kubernetes Secret named X." The controller reconciles on a schedule (`refreshInterval`) and any time the ExternalSecret spec changes.
+
+```text
+ClusterSecretStore ──authenticates──► AWS Secrets Manager
+        │
+ExternalSecret ──references──► ClusterSecretStore
+        │
+        ▼ (reconcile)
+Kubernetes Secret (consumed by pods normally)
+```
+
+## On AWS (what we run)
+
+### ClusterSecretStore with IRSA
+
+The PublicDemo platform uses a `ClusterSecretStore` named `public-demo` backed by AWS Secrets Manager, authenticated via IRSA (IAM Roles for Service Accounts). The External Secrets Operator service account carries the IAM role annotation; the CRD itself only specifies the service and region:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: public-demo
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-west-2
+```
+
+The IRSA binding lives in the cluster's IAM configuration (managed by the cloud team), not in this resource. The convention for secret names in AWS Secrets Manager is `publicdemo/{secret-name}`, so all secrets for this application live under a single path prefix.
+
+<!-- VERIFY: confirm the exact IRSA IAM role ARN or annotation pattern lives in the cluster-config chart or EKS setup docs, not in the external-secrets chart values -->
+
+### ExternalSecrets in the Helm chart
+
+The public-demo Helm chart (`charts/public-demo/templates/external-secrets.yaml`) creates four ExternalSecrets. All four reference the same AWS Secrets Manager secret (`se-public-demo-83`) and extract different JSON properties from it into separate Kubernetes Secrets.
+
+**Git credentials** (two keys from one AWS secret):
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: git-sync-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: public-demo
+    kind: ClusterSecretStore
+  target:
+    name: git-sync-secret
+    creationPolicy: Owner
+  data:
+  - secretKey: ssh
+    remoteRef:
+      key: se-public-demo-83
+      property: GIT_SYNC_SSH
+  - secretKey: known_hosts
+    remoteRef:
+      key: se-public-demo-83
+      property: GIT_SYNC_KNOWN_HOSTS
+```
+
+The resulting `git-sync-secret` Kubernetes Secret is mounted into the git-sync init container at `/etc/git-secret`, with `ssh` and `known_hosts` keys matching what `git` expects.
+
+**Ignition API key** (used by Stoker and git-sync to call the gateway):
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ignition-api-key
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: public-demo
+    kind: ClusterSecretStore
+  target:
+    name: ignition-api-key
+    creationPolicy: Owner
+  data:
+  - secretKey: apiKey
+    remoteRef:
+      key: se-public-demo-83
+      property: IGNITION_API_KEY
+```
+
+**Leased license** (the license key and activation token for Ignition's leased activation model):
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: public-demo-leased-license
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: public-demo
+    kind: ClusterSecretStore
+  target:
+    name: public-demo-leased-license
+    creationPolicy: Owner
+  data:
+  - secretKey: ignition-license-key
+    remoteRef:
+      key: se-public-demo-83
+      property: IGNITION_LICENSE_KEY
+  - secretKey: ignition-activation-token
+    remoteRef:
+      key: se-public-demo-83
+      property: IGNITION_ACTIVATION_TOKEN
+```
+
+The `public-demo-leased-license` Secret is referenced by the gateway values:
+
+```yaml
+frontend:
+  gateway:
+    licensing:
+      leasedActivation:
+        secretName: "public-demo-leased-license"
+```
+
+The chart values that control the ExternalSecret configuration live at the top level:
+
+```yaml
+externalSecrets:
+  secretName: "se-public-demo-83"       # the AWS Secrets Manager secret name
+  clusterSecretStore: "public-demo"      # which ClusterSecretStore to use
+  refreshInterval: "1h"
+```
+
+All ExternalSecret templates read from `externalSecrets.secretName`, so switching to a different AWS secret is a single values override.
+
+### Sync wave ordering
+
+All four ExternalSecrets carry `argocd.argoproj.io/sync-wave: "0"`, ensuring they sync after the ClusterSecretStore (wave `-1`) but before gateways come up. The Kubernetes Secrets exist by the time gateway pods first start.
+
+## On other platforms
+
+The External Secrets Operator supports many providers beyond AWS Secrets Manager, including GCP Secret Manager, Azure Key Vault, and HashiCorp Vault. The `ClusterSecretStore` spec's `provider` block changes; the `ExternalSecret` structure and the pod consumption pattern are identical across providers.
+
+On bare-metal clusters without a cloud secret store, [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or [SOPS](https://github.com/getsops/sops) are common alternatives that encrypt secrets for Git storage.
+
+## Further reading
+
+- [External Secrets Operator documentation](https://external-secrets.io/latest/)
+- [Ignition leased licensing](https://docs.inductiveautomation.com/docs/8.3/platform-concepts/modules-and-licensing/leased-licensing)

--- a/docs/guides/kubernetes/gitops-applicationsets.md
+++ b/docs/guides/kubernetes/gitops-applicationsets.md
@@ -1,0 +1,148 @@
+---
+sidebar_position: 5
+applies_to: [kubernetes]
+---
+
+# GitOps with ArgoCD ApplicationSets
+
+Managing Ignition gateways across multiple environments and regions manually - applying Helm charts, tracking drift, promoting versions - does not scale. ArgoCD ApplicationSets automate this by generating ArgoCD Applications from a matrix of clusters and configuration files. Adding a new region requires no changes to the ApplicationSet itself; you add a config file and the ApplicationSet discovers it.
+
+## How It Works
+
+An [ApplicationSet](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/) is an ArgoCD resource that generates multiple ArgoCD Applications from a set of generators. A **matrix generator** combines two generators so that every combination of their outputs produces an Application.
+
+The PublicDemo platform uses a two-generator matrix:
+
+1. **Cluster generator**: queries the ArgoCD cluster registry for clusters that match a label selector (e.g., `env: prod`)
+2. **Git file generator**: scans the deployment repository for files matching a path pattern (e.g., `values/*/prod/<region>/config.yaml`)
+
+Every `(cluster, config-file)` pair produces one ArgoCD Application. The chart name is extracted from the path, the namespace from the `config.yaml` content, and the cluster from the cluster generator output.
+
+```text
+clusters matching env=prod   x   values/*/prod/us-west-2/config.yaml
+        │                              │
+        └──────────────────────────────┘
+                         │
+               ArgoCD Application per match
+```
+
+## The config.yaml Discovery Marker
+
+Each `values/{chart}/{env}/{region}/config.yaml` file is the signal that a chart should deploy to that cluster. The file typically contains only:
+
+```yaml
+namespace: public-demo
+```
+
+**Adding a chart to an environment = creating its `config.yaml` in the right path.** The ApplicationSet controller scans for this file on every push to main. When it finds a new one, it creates the corresponding ArgoCD Application. When the file is removed, the Application is also removed (subject to the `applicationsSync` policy).
+
+From `docs/architecture.md`:
+
+> Adding a chart to an environment requires only:
+> 1. Create the values directory structure for the chart
+> 2. Add a `config.yaml` in the region directory
+> 3. The ApplicationSet automatically creates an ArgoCD Application
+
+## The Helm Values Layering
+
+Each generated Application mounts three Helm values files, applied in order (later overrides earlier):
+
+```yaml
+valueFiles:
+  - $values/values/{chart}/common-values.yaml
+  - $values/values/{chart}/{env}/environment-values.yaml
+  - $values/values/{chart}/{env}/{region}/values.yaml
+```
+
+`ignoreMissingValueFiles: true` means any layer that does not exist is skipped silently, so a chart can have only `common-values.yaml` and a region `values.yaml` without an environment layer. This is the 4-layer model described in detail in the [Values Layering reference](../../reference/values-layering.md).
+
+## ApplicationSet Structure
+
+From `appsets/appset-dev.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: appset-dev
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  env: "dev"
+                matchExpressions:
+                  - key: region
+                    operator: In
+                    values: ["us-west-2"]
+          - git:
+              repoURL: org-147873951@github.com:inductive-automation/publicdemo-k8s.git
+              revision: main
+              files:
+                - path: values/*/dev/{{ .metadata.labels.region }}/config.yaml
+  template:
+    metadata:
+      name: '{{ index .path.segments 1 }}-{{ .name }}'
+    spec:
+      project: development
+      sources:
+        - repoURL: 'org-147873951@github.com:inductive-automation/publicdemo-k8s.git'
+          path: 'charts/{{ index .path.segments 1 }}'
+          targetRevision: main
+          helm:
+            releaseName: '{{ index .path.segments 1 }}'
+            valueFiles:
+              - '$values/values/{{ index .path.segments 1 }}/common-values.yaml'
+              - '$values/values/{{ index .path.segments 1 }}/dev/environment-values.yaml'
+              - '$values/values/{{ index .path.segments 1 }}/dev/{{ .metadata.labels.region }}/values.yaml'
+            ignoreMissingValueFiles: true
+        - repoURL: 'org-147873951@github.com:inductive-automation/publicdemo-k8s.git'
+          targetRevision: main
+          ref: values
+      destination:
+        server: '{{ .server }}'
+        namespace: '{{ dig "namespace" (index .path.segments 1) . }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+          - CreateNamespace=true
+```
+
+Key design choices visible here:
+
+- **`goTemplate: true`** with **`missingkey=error`**: uses Go templating for the Application template fields and fails loudly on missing cluster labels rather than silently producing broken Applications
+- **Two sources, one `ref`**: the first source fetches the chart from `charts/{chart-name}`, the second fetches the values repo into `$values` so value files can reference it with the `$values` alias
+- **`index .path.segments 1`**: extracts the chart name from the `config.yaml` path (segment 1 of `values/{chart}/{env}/{region}/config.yaml`)
+- **`CreateNamespace=true`**: ArgoCD creates the namespace automatically; no manual `kubectl create namespace` needed
+
+## Cluster Registration and Labels
+
+Clusters are registered in ArgoCD with labels that the matrix generators use:
+
+```bash
+argocd cluster add <context-name> \
+  --name publicdemo-<env>-<region> \
+  --label env=<env> \
+  --label region=<region>
+```
+
+The `env` and `region` labels on each registered cluster are the only coupling between the cluster and the ApplicationSet. A prod cluster with `env=prod, region=us-west-2` will receive any chart that has a `values/*/prod/us-west-2/config.yaml`.
+
+## GitOps Flow End to End
+
+1. A developer merges a PR to `main` in the platform repository
+2. ArgoCD detects the change (via webhook or poll)
+3. ArgoCD re-renders the ApplicationSet, discovering any new or removed `config.yaml` files
+4. For each Application, ArgoCD renders the Helm chart with the layered values
+5. ArgoCD applies the rendered manifests to the target cluster
+6. Self-heal (`selfHeal: true`) corrects any out-of-band changes to cluster state
+
+Application version promotion (updating `git.ref` to point gateways at a new tag of the application repo) is handled by Kargo, which writes directly to the platform repository's values files and lets ArgoCD pick up the change through the same GitOps flow.

--- a/docs/guides/kubernetes/gitops-applicationsets.md
+++ b/docs/guides/kubernetes/gitops-applicationsets.md
@@ -39,6 +39,7 @@ namespace: public-demo
 From `docs/architecture.md`:
 
 > Adding a chart to an environment requires only:
+>
 > 1. Create the values directory structure for the chart
 > 2. Add a `config.yaml` in the region directory
 > 3. The ApplicationSet automatically creates an ArgoCD Application

--- a/docs/guides/kubernetes/intro.md
+++ b/docs/guides/kubernetes/intro.md
@@ -18,8 +18,12 @@ The official Helm chart at [charts.ia.io](https://charts.ia.io) assembles most o
 ## What's here
 
 - **[Kubernetes concepts for Ignition](./concepts.md)**: the cluster primitives the Helm chart relies on (StatefulSets, PVCs, Services, ConfigMaps, Secrets) and why Ignition needs each one.
+- **[External modules from S3](./external-modules-s3.md)**: mount third-party `.modl` files from an S3 bucket into all gateways in the namespace without baking them into pods.
+- **[External Secrets](./external-secrets.md)**: wire AWS Secrets Manager (or any provider) to Kubernetes Secrets via the External Secrets Operator, covering the license key, git credentials, and API key.
+- **[GitOps with ApplicationSets](./gitops-applicationsets.md)**: use ArgoCD's matrix generator and a `config.yaml` discovery marker to deploy charts across clusters automatically.
+- **[Config Sync](./config-sync.md)**: keep Ignition project files and gateway config in sync with Git using the Stoker operator's `GatewaySync` resource.
 
-More guides land in later rounds: external modules from S3, config sync, external secrets, GitOps with ApplicationSets, and promotion with Kargo. Short, one-screen operational tips will be collected here under a **Tasks** sub-section as the pillar grows, following the [Kubernetes documentation](https://kubernetes.io/docs/) Concepts / Tasks / Tutorials / Reference convention.
+Short, one-screen operational tips will be collected here under a **Tasks** sub-section as the pillar grows, following the [Kubernetes documentation](https://kubernetes.io/docs/) Concepts / Tasks / Tutorials / Reference convention.
 
 ## Related
 

--- a/docs/reference/architecture-index.md
+++ b/docs/reference/architecture-index.md
@@ -6,13 +6,17 @@ There are two platform paths: Kubernetes and Docker Compose.
 
 ## Kubernetes
 
-Read the mental model first, then size and deploy a gateway, then add observability.
+Read the mental model first, then size and deploy a gateway, then add the operational patterns.
 
 1. [Running Ignition on Kubernetes](../guides/kubernetes/intro.md): how the cluster machinery maps onto a gateway.
 2. [Kubernetes concepts for Ignition](../guides/kubernetes/concepts.md): the StatefulSet, PVC, Service, and Secret choices behind the Helm chart.
 3. [Kubernetes Sizing Reference](./kubernetes-sizing.md): CPU, memory, heap, and PVC starting points.
 4. [Helm Ignition Lab](../labs/helm-ignition-lab.md): deploy a gateway on a cluster end to end.
-5. [Observability for Ignition](../guides/observability/intro.md): what to monitor and how the stack fits together.
+5. [External modules from S3](../guides/kubernetes/external-modules-s3.md): share third-party `.modl` files across gateway pods via a ReadOnlyMany PV.
+6. [External Secrets](../guides/kubernetes/external-secrets.md): sync credentials from a cloud secret store into Kubernetes Secrets.
+7. [GitOps with ApplicationSets](../guides/kubernetes/gitops-applicationsets.md): automate multi-cluster, multi-environment deployments with ArgoCD matrix generators.
+8. [Config Sync](../guides/kubernetes/config-sync.md): keep Ignition project files and gateway config continuously in sync with Git.
+9. [Observability for Ignition](../guides/observability/intro.md): what to monitor and how the stack fits together.
 
 :::note Managed and self-hosted clusters use the same path
 

--- a/docs/reference/values-layering.md
+++ b/docs/reference/values-layering.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 6
+---
+
+# Helm Values Layering
+
+The PublicDemo platform composes Helm values in four layers to avoid duplication across environments and regions. Each layer overrides the previous. ArgoCD applies them in order using Helm's standard multi-file merge behavior.
+
+## Layer Order
+
+| Layer | File path | Purpose |
+|-------|-----------|---------|
+| 1. Chart defaults | `charts/{chart}/values.yaml` | Shipped with the chart; all keys present with defaults |
+| 2. Common values | `values/{chart}/common-values.yaml` | Shared across all environments (observability endpoints, ingress class, etc.) |
+| 3. Environment values | `values/{chart}/{env}/environment-values.yaml` | Shared across all regions in one environment (prod vs dev log levels, Stoker on/off, etc.) |
+| 4. Region values | `values/{chart}/{env}/{region}/values.yaml` | Region-specific overrides (bucket names, ALB ARNs, hostnames, replicas) |
+
+Layer 1 is implicit - Helm always reads the chart's bundled `values.yaml`. Layers 2-4 are specified in the ApplicationSet's `valueFiles` list.
+
+## valueFiles Order in the ApplicationSet
+
+From `appsets/appset-dev.yaml` (prod and test follow the same pattern):
+
+```yaml
+helm:
+  valueFiles:
+    - $values/values/{{ chart }}/common-values.yaml           # Layer 2
+    - $values/values/{{ chart }}/{{ env }}/environment-values.yaml  # Layer 3
+    - $values/values/{{ chart }}/{{ env }}/{{ region }}/values.yaml  # Layer 4
+  ignoreMissingValueFiles: true
+```
+
+`$values` is a second ArgoCD source that points to the same repository revision, providing a stable reference alias for value file paths. `ignoreMissingValueFiles: true` means a missing layer is silently skipped, so a chart can opt into only the layers it needs.
+
+## Concrete Example
+
+For `public-demo` in `prod/us-west-2`, the composed values are:
+
+```text
+charts/public-demo/values.yaml                           ← Layer 1 (chart defaults)
+values/public-demo/common-values.yaml                    ← Layer 2 (all envs)
+values/public-demo/prod/environment-values.yaml          ← Layer 3 (prod only)
+values/public-demo/prod/us-west-2/values.yaml            ← Layer 4 (this region)
+```
+
+A key like `s3Modules.bucketName` is set to `""` in Layer 1 (the chart default), not overridden in Layers 2 or 3 (not applicable cross-region), and set to `pd83-prd-ignition-modules-us` in Layer 4.
+
+A key like `otelInstrumentation.enabled` is set to `false` in Layer 1 and overridden to `true` in Layer 2 (common-values), applying to all environments.
+
+## What Lives in Each Layer
+
+**Common values (Layer 2)** - things that are the same in every environment:
+- Ingress annotations that don't vary by region (ALB scheme, health check path, protocol)
+- Observability endpoint URIs (OTEL collector service DNS name)
+- Stoker annotation labels (pod labels are the same shape everywhere)
+- `externalModules.enabled: true` (feature flag, always on)
+
+**Environment values (Layer 3)** - things that differ between prod/test/dev:
+- `stoker.enabled` (enabled in prod, disabled in dev)
+- Log level and format (`wrapperArgs`)
+- Module enable lists (`GATEWAY_MODULES_ENABLED`)
+- OTel environment label (`otelInstrumentation.prometheus.env`)
+
+**Region values (Layer 4)** - things that differ region by region:
+- `s3Modules.bucketName` and `s3Modules.region`
+- ALB certificate ARN
+- External DNS hostname
+- `git.ref` (the specific application version deployed here)
+- Replica counts and autoscaling triggers
+
+## The config.yaml Discovery Marker
+
+Each `values/{chart}/{env}/{region}/` directory contains a `config.yaml` alongside `values.yaml`. This file is not a Helm values file - it is the ArgoCD ApplicationSet discovery marker. It tells the ApplicationSet that this chart should be deployed to clusters matching the `(env, region)` path.
+
+```yaml
+# values/public-demo/prod/us-west-2/config.yaml
+namespace: public-demo
+```
+
+The ApplicationSet's Git file generator scans for files at `values/*/{env}/{region}/config.yaml`. Finding one creates an ArgoCD Application for that chart on that cluster. See [GitOps with ApplicationSets](../guides/kubernetes/gitops-applicationsets.md) for the full ApplicationSet structure.
+
+## Helm Merge Behavior
+
+Helm merges values files with a last-write-wins deep merge. A key set in Layer 3 is overridden by the same key in Layer 4, but a key present only in Layer 2 is not removed by Layer 4 setting other keys at the same depth. Arrays are replaced, not appended - if Layer 3 sets `jvmArgs: ["-Xmx4g"]` and Layer 4 sets `jvmArgs: ["-Xmx8g"]`, the result is `["-Xmx8g"]`, not `["-Xmx4g", "-Xmx8g"]`.

--- a/docs/reference/values-layering.md
+++ b/docs/reference/values-layering.md
@@ -9,7 +9,7 @@ The PublicDemo platform composes Helm values in four layers to avoid duplication
 ## Layer Order
 
 | Layer | File path | Purpose |
-|-------|-----------|---------|
+| --- | --- | --- |
 | 1. Chart defaults | `charts/{chart}/values.yaml` | Shipped with the chart; all keys present with defaults |
 | 2. Common values | `values/{chart}/common-values.yaml` | Shared across all environments (observability endpoints, ingress class, etc.) |
 | 3. Environment values | `values/{chart}/{env}/environment-values.yaml` | Shared across all regions in one environment (prod vs dev log levels, Stoker on/off, etc.) |
@@ -50,18 +50,21 @@ A key like `otelInstrumentation.enabled` is set to `false` in Layer 1 and overri
 ## What Lives in Each Layer
 
 **Common values (Layer 2)** - things that are the same in every environment:
+
 - Ingress annotations that don't vary by region (ALB scheme, health check path, protocol)
 - Observability endpoint URIs (OTEL collector service DNS name)
 - Stoker annotation labels (pod labels are the same shape everywhere)
 - `externalModules.enabled: true` (feature flag, always on)
 
 **Environment values (Layer 3)** - things that differ between prod/test/dev:
+
 - `stoker.enabled` (enabled in prod, disabled in dev)
 - Log level and format (`wrapperArgs`)
 - Module enable lists (`GATEWAY_MODULES_ENABLED`)
 - OTel environment label (`otelInstrumentation.prometheus.env`)
 
 **Region values (Layer 4)** - things that differ region by region:
+
 - `s3Modules.bucketName` and `s3Modules.region`
 - ALB certificate ARN
 - External DNS hostname

--- a/docs/tools/stoker-operator.md
+++ b/docs/tools/stoker-operator.md
@@ -33,3 +33,7 @@ Stoker is for teams running Ignition on Kubernetes who want GitOps-style config 
 - [Quickstart](https://ia-eknorr.github.io/stoker-operator/quickstart)
 - [Installation](https://ia-eknorr.github.io/stoker-operator/installation)
 - [Helm Values Reference](https://ia-eknorr.github.io/stoker-operator/reference/helm-values)
+
+## End-to-End Config Sync Guide
+
+For a walkthrough of setting up config sync in a real Ignition deployment - including the `GatewaySync` resource, SSH auth wiring, profile mappings, and the fallback git-sync approach - see [Config Sync](../guides/kubernetes/config-sync.md).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -33,7 +33,13 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "Kubernetes",
           link: { type: "doc", id: "guides/kubernetes/intro" },
-          items: ["guides/kubernetes/concepts"],
+          items: [
+            "guides/kubernetes/concepts",
+            "guides/kubernetes/external-modules-s3",
+            "guides/kubernetes/external-secrets",
+            "guides/kubernetes/gitops-applicationsets",
+            "guides/kubernetes/config-sync",
+          ],
         },
         {
           type: "category",
@@ -72,6 +78,7 @@ const sidebars: SidebarsConfig = {
         "reference/resource-collections",
         "reference/docker-command-reference",
         "reference/kubernetes-sizing",
+        "reference/values-layering",
       ],
     },
     {


### PR DESCRIPTION
### Background

Round one of the DevOps content venture grows the Kubernetes section from a single concepts page into a real Guides pillar (Phases 4 and 5 of the plan). These cover the integration and operational patterns the official Helm chart leaves to the operator: mounting modules, syncing secrets and config from external sources, and GitOps delivery.

### Changes

Four new guides plus a reference, all grounded in the `publicdemo-k8s` and `conf-proveit26-platform` source repos:

- **`guides/kubernetes/external-modules-s3.md`**: sharing `.modl` files across gateway pods via a `ReadOnlyMany` PV backed by the AWS Mountpoint S3 CSI driver (backend creates the PVC, frontends mount it).
- **`guides/kubernetes/external-secrets.md`**: External Secrets Operator wiring (ClusterSecretStore + ExternalSecret) for the Ignition license, git credentials, API key, and admin password, with the AWS Secrets Manager worked example.
- **`guides/kubernetes/gitops-applicationsets.md`**: ArgoCD ApplicationSets matrix generator and the `config.yaml` discovery marker ("add a chart = add a config.yaml").
- **`guides/kubernetes/config-sync.md`**: Stoker `GatewaySync` as the recommended path to push project/config from Git into running gateways without pod restarts, with git-sync noted as a fallback only.
- **`reference/values-layering.md`**: the 4-layer Helm values compose model.
- Fills the `kubernetes/intro` landing links, cross-links `tools/stoker-operator`, registers all pages in `sidebars.ts`, and extends the `architecture-index` Kubernetes path.

### Reviewer Notes

Every YAML block was copied from the actual source templates and re-verified against them (the `GatewaySync` spec, the `s3Modules`/`externalModules` values, the ExternalSecret keys, the `appset-dev.yaml` ApplicationSet, the `pd83-<env>-ignition-modules-<region-short>` bucket convention). Core-product concepts (leased licensing, deployment modes) link to docs.ia.io/8.3 and chart value semantics to charts.ia.io rather than being re-explained. The scan-API endpoints (`/data/api/v1/scan/projects`, `/data/api/v1/scan/config`) are the real calls Stoker/git-sync make. Build passes clean with `onBrokenLinks: throw`; markdownlint clean.