### PR TITLE
docs: tokenize ignition version in observability pages

### DIFF
--- a/docs/guides/observability/gateway-telemetry.md
+++ b/docs/guides/observability/gateway-telemetry.md
@@ -39,7 +39,7 @@ The agent JAR is mounted into the container from the host and passed to the JVM 
 ```yaml
 services:
   ignition:
-    image: inductiveautomation/ignition:8.3.6
+    image: inductiveautomation/ignition:__IGNITION_VERSION__
     volumes:
       # Mount the agent JAR and (optionally) the properties file
       - ./dependencies:/usr/local/bin/ignition/dependencies
@@ -112,7 +112,7 @@ For the full `ignition.conf` structure and existing `wrapper.java.additional.*` 
 
 # --- Identity ---
 otel.service.name=my-gateway
-otel.resource.attributes=service.name=my-gateway,gateway=my-gateway,environment=Production,ignition.version=8.3.6
+otel.resource.attributes=service.name=my-gateway,gateway=my-gateway,environment=Production,ignition.version=__IGNITION_VERSION__
 
 # --- Exporter ---
 otel.exporter.otlp.protocol=http/protobuf

--- a/docs/reference/ignition-otel-properties.md
+++ b/docs/reference/ignition-otel-properties.md
@@ -13,7 +13,7 @@ For wiring instructions see [Gateway Telemetry](../guides/observability/gateway-
 | Property | Example value | Description |
 | --- | --- | --- |
 | `otel.service.name` | `my-gateway` | The service name attached to every metric, trace, and log record. Appears as the `service.name` resource attribute. Should match the gateway name for easy correlation. |
-| `otel.resource.attributes` | `gateway=gw1,environment=Production,ignition.version=8.3.6` | Comma-separated key=value pairs added to every signal as resource attributes. Useful for filtering in Grafana across multiple gateways or environments. |
+| `otel.resource.attributes` | `gateway=gw1,environment=Production,ignition.version=__IGNITION_VERSION__` | Comma-separated key=value pairs added to every signal as resource attributes. Useful for filtering in Grafana across multiple gateways or environments. |
 
 ## Exporter protocol
 


### PR DESCRIPTION
## Why

The Observability pillar (#51) hardcoded `8.3.6` in three places — a docker-compose image tag and two `ignition.version` OTel resource-attribute examples. The site deliberately parameterizes the Ignition version through the `IGNITION_VERSION` constant and `remarkTokenSubstitution` (PR #39), so the rest of the docs write `inductiveautomation/ignition:__IGNITION_VERSION__` and let renovate bump it everywhere at once. The hardcoded values render identically today but silently drift on the next version bump and read as "not part of this site" to a maintainer.

This aligns the three remaining literals with the convention. Verified the build substitutes them (rendered `ignition.version=8.3.6`, zero leftover `__IGNITION_VERSION__` tokens in `build/`).