### PR TITLE
docs: credit the Helm-values-with-Argo-CD article in values layering

### DIFF
--- a/docs/reference/values-layering.md
+++ b/docs/reference/values-layering.md
@@ -85,3 +85,7 @@ The ApplicationSet's Git file generator scans for files at `values/*/{env}/{regi
 ## Helm Merge Behavior
 
 Helm merges values files with a last-write-wins deep merge. A key set in Layer 3 is overridden by the same key in Layer 4, but a key present only in Layer 2 is not removed by Layer 4 setting other keys at the same depth. Arrays are replaced, not appended - if Layer 3 sets `jvmArgs: ["-Xmx4g"]` and Layer 4 sets `jvmArgs: ["-Xmx8g"]`, the result is `["-Xmx8g"]`, not `["-Xmx4g", "-Xmx8g"]`.
+
+## Further reading
+
+- [Storing Helm values with Argo CD](https://octopus.com/blog/helm-values-argocd) by Kostis Kapelonis: the multi-source `$values` pattern and the layered values approach this repository structure is built on


### PR DESCRIPTION
### Background

The Helm Values Layering reference documents the four-layer values model and the multi-source `$values` ApplicationSet pattern, but never credited where that structure originates. The whole layout is built on Kostis Kapelonis' Octopus article on storing Helm values with Argo CD. Keeping the link in the docs gives readers the source for the rationale and makes it easy to revisit. The companion internal docs (docs-common) already cite this article; this brings the public guide in line.

### Changes

- Add a **Further reading** section to `docs/reference/values-layering.md` linking the [Storing Helm values with Argo CD](https://octopus.com/blog/helm-values-argocd) article.

### Reviewer Notes

Single external link in a new Further reading section. `npm run build` passes with no broken-link errors.
