### PR TITLE
docs: repoint ia-eknorr references to knorrlabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml"><img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
-  <a href="https://ia-eknorr.github.io/ignition-guides/"><img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" /></a>
+  <a href="https://knorrlabs.github.io/ignition-guides/"><img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
 </p>
 

--- a/docs/guides/kubernetes/config-sync.md
+++ b/docs/guides/kubernetes/config-sync.md
@@ -151,5 +151,5 @@ The git-sync approach requires volumes (`git-secret`, `ignition-api-key-secret`,
 ## Further Reading
 
 - [Stoker operator page](../../tools/stoker-operator.md): installation, full CRD field reference, webhook receiver, Helm values
-- [Stoker upstream docs](https://ia-eknorr.github.io/stoker-operator/): quickstart, installation reference
+- [Stoker upstream docs](https://knorrlabs.github.io/stoker-operator/): quickstart, installation reference
 - [Ignition scan APIs](https://docs.inductiveautomation.com/docs/8.3/): the `/data/api/v1/scan/projects` and `/data/api/v1/scan/config` endpoints that Stoker calls after syncing

--- a/docs/tools/stoker-operator.md
+++ b/docs/tools/stoker-operator.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # Stoker Operator
 
 **GitHub**: [ia-eknorr/stoker-operator](https://github.com/ia-eknorr/stoker-operator)  
-**Docs**: [ia-eknorr.github.io/stoker-operator](https://ia-eknorr.github.io/stoker-operator/)
+**Docs**: [knorrlabs.github.io/stoker-operator](https://knorrlabs.github.io/stoker-operator/)
 
 ## What It Does
 
@@ -30,9 +30,9 @@ Stoker is for teams running Ignition on Kubernetes who want GitOps-style config 
 
 ## Quick Links
 
-- [Quickstart](https://ia-eknorr.github.io/stoker-operator/quickstart)
-- [Installation](https://ia-eknorr.github.io/stoker-operator/installation)
-- [Helm Values Reference](https://ia-eknorr.github.io/stoker-operator/reference/helm-values)
+- [Quickstart](https://knorrlabs.github.io/stoker-operator/quickstart)
+- [Installation](https://knorrlabs.github.io/stoker-operator/installation)
+- [Helm Values Reference](https://knorrlabs.github.io/stoker-operator/reference/helm-values)
 
 ## End-to-End Config Sync Guide
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
   url: "https://ia-eknorr.github.io",
   baseUrl: "/ignition-guides/",
 
-  organizationName: "ia-eknorr",
+  organizationName: "knorrlabs",
   projectName: "ignition-guides",
 
   future: {
@@ -79,7 +79,7 @@ const config: Config = {
         docs: {
           sidebarPath: "./sidebars.ts",
           editUrl:
-            "https://github.com/ia-eknorr/ignition-guides/tree/main/",
+            "https://github.com/knorrlabs/ignition-guides/tree/main/",
           beforeDefaultRemarkPlugins: [
             [remarkTokenSubstitution, { tokens: { IGNITION_VERSION } }],
           ],
@@ -108,7 +108,7 @@ const config: Config = {
           label: "Docs",
         },
         {
-          href: "https://github.com/ia-eknorr/ignition-guides",
+          href: "https://github.com/knorrlabs/ignition-guides",
           label: "GitHub",
           position: "right",
         },
@@ -132,7 +132,7 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/ia-eknorr/ignition-guides",
+              href: "https://github.com/knorrlabs/ignition-guides",
             },
             {
               label: "Stoker Operator",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,7 +9,7 @@ const config: Config = {
   tagline: "Community guides for Ignition SCADA using modern development practices",
   favicon: "img/favicon.ico",
 
-  url: "https://ia-eknorr.github.io",
+  url: "https://knorrlabs.github.io",
   baseUrl: "/ignition-guides/",
 
   organizationName: "knorrlabs",
@@ -136,7 +136,7 @@ const config: Config = {
             },
             {
               label: "Stoker Operator",
-              href: "https://ia-eknorr.github.io/stoker-operator/",
+              href: "https://knorrlabs.github.io/stoker-operator/",
             },
           ],
         },


### PR DESCRIPTION
## Why

The repo moved to the `knorrlabs` org. GitHub **Pages** URLs do not redirect (unlike repo URLs), so every hardcoded `ia-eknorr.github.io/...` link now 404s and the docs link-check fails.

## What

- Repoint `ia-eknorr.github.io` → `knorrlabs.github.io` (Pages links + Docusaurus `url`)
- Update `organizationName` (and config `editUrl`) to `knorrlabs`

Redirect-covered references (go.mod module path, Go imports, repo URLs) are intentionally left for the broader Phase 3 sweep.