### PR TITLE
chore: repoint remaining ia-eknorr refs to knorrlabs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "reviewers": ["ia-eknorr"],
+  "reviewers": ["etknorr"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml"><img src="https://github.com/ia-eknorr/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
+  <a href="https://github.com/knorrlabs/ignition-guides/actions/workflows/deploy.yml"><img src="https://github.com/knorrlabs/ignition-guides/actions/workflows/deploy.yml/badge.svg" alt="Deploy" /></a>
   <a href="https://knorrlabs.github.io/ignition-guides/"><img src="https://img.shields.io/badge/docs-live-blue" alt="Docs" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
 </p>
@@ -28,7 +28,7 @@
 
 ## Contributing
 
-Found an error or want to add something? Open an issue or pull request on [GitHub](https://github.com/ia-eknorr/ignition-guides).
+Found an error or want to add something? Open an issue or pull request on [GitHub](https://github.com/knorrlabs/ignition-guides).
 
 ## Local Development
 

--- a/docs/tools/stoker-operator.md
+++ b/docs/tools/stoker-operator.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Stoker Operator
 
-**GitHub**: [ia-eknorr/stoker-operator](https://github.com/ia-eknorr/stoker-operator)  
+**GitHub**: [knorrlabs/stoker-operator](https://github.com/knorrlabs/stoker-operator)  
 **Docs**: [knorrlabs.github.io/stoker-operator](https://knorrlabs.github.io/stoker-operator/)
 
 ## What It Does


### PR DESCRIPTION
### Background

The ignition-guides repo was transferred to the `knorrlabs` GitHub org. PR #60 covered the Docusaurus config, but a few hardcoded `ia-eknorr` references remained in the README and Renovate config.

### Changes

- README.md: updated deploy badge href and CI badge image src from `github.com/ia-eknorr/ignition-guides` → `github.com/knorrlabs/ignition-guides`; updated Contributing link to same
- .github/renovate.json: changed reviewer from `ia-eknorr` (org bot account) to `etknorr` (user account) so Renovate PRs route to the right reviewer

### Reviewer Notes

Remaining `ia-eknorr` refs exist in `docs/` content files but all point to **other** repos (`project-template`, `stoker-operator`, `traefik-reverse-proxy`) that are outside the scope of this PR. Those should be updated if/when those repos are also migrated.

Build verified: `npm run build` passes with no errors.