### PR TITLE
docs: fix stale account references and the stoker chart location

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 ia-eknorr
+Copyright (c) 2025 etknorr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/getting-started/traefik.md
+++ b/docs/getting-started/traefik.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Traefik Reverse Proxy
 
-**GitHub**: [ia-eknorr/traefik-reverse-proxy](https://github.com/ia-eknorr/traefik-reverse-proxy)
+**GitHub**: [etknorr/traefik-reverse-proxy](https://github.com/etknorr/traefik-reverse-proxy)
 
 Traefik is a lightweight reverse proxy that runs alongside your Docker stacks and gives
 each service a friendly local URL instead of a port number.
@@ -40,7 +40,7 @@ once and leave it running.
    ```shell
    mkdir -p ~/projects/utilities
    cd ~/projects/utilities
-   git clone https://github.com/ia-eknorr/traefik-reverse-proxy.git traefik
+   git clone https://github.com/etknorr/traefik-reverse-proxy.git traefik
    cd traefik
    ```
 

--- a/docs/guides/docker/compose-architecture.md
+++ b/docs/guides/docker/compose-architecture.md
@@ -11,7 +11,7 @@ sidebar_position: 2
 
 :::
 
-The [Project Template](https://github.com/ia-eknorr/project-template) defines three services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
+The [Project Template](https://github.com/etknorr/project-template) defines three services in its compose file. Each one exists for a specific reason. This guide walks through exactly what happens when you run `docker compose up`, service by service.
 
 ## The Three Services
 

--- a/docs/guides/docker/day-two-operations.md
+++ b/docs/guides/docker/day-two-operations.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Day-Two Operations
 
-This guide covers everything you need to operate an Ignition gateway running in Docker after the initial setup. It assumes the gateway is already running from the [Project Template](https://github.com/ia-eknorr/project-template).
+This guide covers everything you need to operate an Ignition gateway running in Docker after the initial setup. It assumes the gateway is already running from the [Project Template](https://github.com/etknorr/project-template).
 
 :::tip Before continuing
 Read [The Compose Architecture](./compose-architecture.md) to understand how the services, volumes, and bind mounts fit together before running any of the commands below.

--- a/docs/guides/docker/intro.md
+++ b/docs/guides/docker/intro.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 
 :::
 
-Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the [Project Template](https://github.com/ia-eknorr/project-template).
+Docker changes how you install, run, and share Ignition gateways. Instead of running an installer on your workstation and managing a system service, you declare a gateway in a compose file and start it with a single command. This guide explains the concepts you need before working with the [Project Template](https://github.com/etknorr/project-template).
 
 ## What Docker Solves for Ignition Developers
 

--- a/docs/guides/docker/volume-strategy.md
+++ b/docs/guides/docker/volume-strategy.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 Read [The Compose Architecture](./compose-architecture.md) before this page.
 :::
 
-The [Project Template](https://github.com/ia-eknorr/project-template) combines two storage mechanisms based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations): a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
+The [Project Template](https://github.com/etknorr/project-template) combines two storage mechanisms based on the [IA Version Control Guide](https://docs.inductiveautomation.com/docs/8.3/tutorials/version-control-guide#advanced-version-control-considerations): a Docker-managed named volume for runtime state, and bind mounts from your repository for the files Git should track. The bind mounts layer on top of the volume at the same paths, so Ignition sees a unified `/data` directory while Git only sees the specific subdirectories you care about.
 
 ## What the named volume holds
 

--- a/docs/guides/version-control/initialize-repository.md
+++ b/docs/guides/version-control/initialize-repository.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Initialize a Local Repository
 
 :::tip Using Docker?
-If you are using the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template) Docker setup, skip this page. The template already includes a pre-initialized repository structure. Fork the template on GitHub and clone it instead of following the steps below.
+If you are using the [etknorr/project-template](https://github.com/etknorr/project-template) Docker setup, skip this page. The template already includes a pre-initialized repository structure. Fork the template on GitHub and clone it instead of following the steps below.
 :::
 
 ## Procedure
@@ -60,7 +60,7 @@ for the full picture.
 
 In Ignition 8.3, project and configuration files are stored on the filesystem (not in a SQLite database), making them directly trackable with Git.
 
-When using Docker with the [ia-eknorr/project-template](https://github.com/ia-eknorr/project-template):
+When using Docker with the [etknorr/project-template](https://github.com/etknorr/project-template):
 
 | Directory | What it Contains |
 | --- | --- |

--- a/docs/labs/docker-ignition-lab.md
+++ b/docs/labs/docker-ignition-lab.md
@@ -22,12 +22,12 @@ This lab is self-contained: you will create a repository from `project-template`
 
 ## Step 0: Create Your Project
 
-The [`ia-eknorr/project-template`](https://github.com/ia-eknorr/project-template) repository
+The [`etknorr/project-template`](https://github.com/etknorr/project-template) repository
 is a pre-configured Ignition 8.3 Docker project. Create your own copy of it.
 
 ### Create the repository on GitHub
 
-1. Go to [github.com/ia-eknorr/project-template](https://github.com/ia-eknorr/project-template)
+1. Go to [github.com/etknorr/project-template](https://github.com/etknorr/project-template)
 2. Click the green **Use this template** button, then select **Create a new repository**
 3. Fill in the form:
    - **Owner**: your personal GitHub account
@@ -57,7 +57,7 @@ copy .env.example .env
 
 Open `.env` in your editor and set `GATEWAY_NAME` to match your repository name (for example, `my-ignition-project`). This becomes the Traefik hostname - your gateway will be available at `https://my-ignition-project.localtest.me`. The default `DB_USER`, `DB_PASSWORD`, and `TZ` are fine for local development.
 
-The gateway ships open by default: the UI does not require a login. A committed admin user (see the [project-template Security section](https://github.com/ia-eknorr/project-template#security)) is available when you need to launch the Designer.
+The gateway ships open by default: the UI does not require a login. A committed admin user (see the [project-template Security section](https://github.com/etknorr/project-template#security)) is available when you need to launch the Designer.
 
 :::note .env stays out of git
 `.env` is listed in `.gitignore` by default. Environment-specific values should never be committed. Share configuration through `.env.example` instead.
@@ -156,7 +156,7 @@ Traefik generates a self-signed certificate for `*.localtest.me`. Your browser w
 The gateway auto-commissions during startup and lands directly on the gateway home page - no login is required to browse the UI. Confirm that the gateway name at the top matches `GATEWAY_NAME` from your `.env` file.
 
 :::note Open by default
-The `project-template` ships open: no login is required to browse the Gateway. You only need to authenticate for privileged operations like launching the Designer. Before any non-local deployment, follow the [Security section of the project-template README](https://github.com/ia-eknorr/project-template#security) to lock it down.
+The `project-template` ships open: no login is required to browse the Gateway. You only need to authenticate for privileged operations like launching the Designer. Before any non-local deployment, follow the [Security section of the project-template README](https://github.com/etknorr/project-template#security) to lock it down.
 :::
 
 ![Gateway homepage](/img/lab/gateway-homepage.png)
@@ -212,7 +212,7 @@ Ignition's license activation is tied to the gateway's UUID. Deriving it from `G
 Launch the Designer from the gateway homepage:
 
 1. Click **Launch Designer** on the gateway homepage
-2. Log in with the committed admin credentials (see the [project-template Security section](https://github.com/ia-eknorr/project-template#security))
+2. Log in with the committed admin credentials (see the [project-template Security section](https://github.com/etknorr/project-template#security))
 3. Click **New Project**, name it `docker_lab` (or similar), and open it
 4. In the Project Browser, right-click **Views** and add a new view named `hello`
 5. Drag a **Label** component onto the view and change its text to something recognizable

--- a/docs/labs/version-control-lab.md
+++ b/docs/labs/version-control-lab.md
@@ -28,12 +28,12 @@ Ensure the following are set up:
 
 ## Step 1: Create Your Repository from the Template
 
-The `ia-eknorr/project-template` gives you a pre-configured Ignition 8.3 Docker project
+The `etknorr/project-template` gives you a pre-configured Ignition 8.3 Docker project
 with the right bind mounts already in place.
 
 ### Create the repository on GitHub
 
-1. Go to [github.com/ia-eknorr/project-template](https://github.com/ia-eknorr/project-template)
+1. Go to [github.com/etknorr/project-template](https://github.com/etknorr/project-template)
 
 2. Click the green **Use this template** button, then select **Create a new repository**:
 

--- a/docs/tools/stoker-operator.md
+++ b/docs/tools/stoker-operator.md
@@ -26,7 +26,7 @@ Stoker is for teams running Ignition on Kubernetes who want GitOps-style config 
 - Supports GitHub App, SSH key, and API token authentication
 - Mutating webhook injects the agent sidecar automatically with namespace/pod labels
 - Webhook receiver supports GitHub releases, ArgoCD notifications, Kargo promotions, and generic payloads
-- Helm chart available at [charts.ia.io](https://charts.ia.io)
+- Helm chart published to `oci://ghcr.io/knorrlabs/charts/stoker-operator`
 
 ## Quick Links
 


### PR DESCRIPTION
### 📖 Background
The `ia-eknorr` account was renamed to `etknorr`. The earlier migration swept this repo's own identity (README badges, `docusaurus.config.ts`, `CODEOWNERS`) but not the outbound links to `project-template` and `traefik-reverse-proxy`, so 22 references survived across the docs plus the `LICENSE` copyright line. They resolve today only through GitHub's rename redirect.

Separately, `docs/tools/stoker-operator.md` listed Stoker's Helm chart as available at `charts.ia.io`. That is Inductive Automation's repository for the Ignition chart. Stoker publishes to GHCR.

### ⚙️ Changes
Repoint every `ia-eknorr` reference at `etknorr`, and correct the Stoker chart location to its GHCR OCI path.

### 📝 Reviewer Notes
Every other `charts.ia.io` link in the repo is genuinely about the Ignition chart and is left alone. Only the Stoker line changed.