### PR TITLE
chore(renovate): adopt the shared org Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>knorrlabs/.github"]
+  "extends": ["github>knorrlabs/renovate-config"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "reviewers": ["etknorr"],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    }
-  ]
+  "extends": ["github>knorrlabs/.github"]
 }


### PR DESCRIPTION
### 📖 Background
The existing config set `automerge: true` for every minor and patch update, which is wrong for a repo that should land changes through review. It has not caused harm only because Renovate stopped running when the `ia-eknorr` account was renamed, so reconnecting it would have started auto merging immediately. Policy now lives in a shared preset at `knorrlabs/.github` so it can change in one place instead of ten.

### ⚙️ Changes
Replace the inline config with an extend of `github>knorrlabs/.github`.

### 📝 Reviewer Notes
The preset disables automerge outright, quarantines releases for seven days, groups Actions and container images, and gates majors behind dashboard approval. It has to merge in `knorrlabs/.github` before this resolves.