### PR TITLE
chore: opt into ignition-automerge preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>knorrlabs/renovate-config"],
+  "extends": [
+    "github>knorrlabs/renovate-config",
+    "github>knorrlabs/renovate-config:ignition-automerge"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Extends the new opt-in `github>knorrlabs/renovate-config:ignition-automerge` preset so patch-level Ignition image bumps automerge after the standard quarantine, same as the pattern in the shared preset repo.